### PR TITLE
Generalize ProcessingConfig

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -736,8 +736,6 @@ etl:
   # Processing settings
   processing:
     num_processes: 2  # Use 2 processes for this small tutorial dataset
-    serialization_method: zarr
-    compression: null
     args: {}
 
   # Validation (runs first)

--- a/physicsnemo_curator/config/domino_etl.yaml
+++ b/physicsnemo_curator/config/domino_etl.yaml
@@ -26,8 +26,6 @@ etl:
 
   processing:
     num_processes: 12
-    serialization_method: zarr
-    compression:
     args: {}
 
   validator:

--- a/physicsnemo_curator/etl/processing_config.py
+++ b/physicsnemo_curator/etl/processing_config.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass, field
-from typing import Any, Literal, Optional
+from typing import Any
 
 
 @dataclass
@@ -23,8 +23,6 @@ class ProcessingConfig:
     """Base configuration for data processing."""
 
     num_processes: int
-    serialization_method: Literal["numpy", "zarr"] = "numpy"
-    compression: Optional[dict[str, Any]] = None
     args: dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self):
@@ -33,22 +31,3 @@ class ProcessingConfig:
             raise ValueError(
                 f"num_processes must be positive, got {self.num_processes}"
             )
-
-        if self.compression is not None and self.serialization_method != "zarr":
-            raise ValueError("Compression is only supported with zarr serialization")
-
-        if self.compression is not None:
-            required_keys = {"method", "level"}
-            missing_keys = required_keys - set(self.compression.keys())
-            if missing_keys:
-                raise ValueError(
-                    f"Compression config missing required keys: {missing_keys}"
-                )
-
-            if not isinstance(self.compression["level"], int) or not (
-                1 <= self.compression["level"] <= 9
-            ):
-                raise ValueError("Compression level must be an integer between 1 and 9")
-
-        if self.serialization_method not in ["numpy", "zarr"]:
-            raise ValueError("Serialization method must be either 'numpy' or 'zarr'")

--- a/physicsnemo_curator/examples/external_aerodynamics/domino/README.md
+++ b/physicsnemo_curator/examples/external_aerodynamics/domino/README.md
@@ -59,6 +59,9 @@ physicsnemo-curator-etl                     \
 - `etl.common.model_type`: can be `surface` (default) or `volume` or `combined`.
     This option is used to specify the type of model that will be trained on the
     dataset.
+- **Output format**: To switch from Zarr (default) to NumPy, make two changes for consistency:
+  1. In `etl.transformations`: uncomment the `numpy` section and comment out the `zarr` section
+  2. In `etl.sink`: set `serialization_method` to `"numpy"`
 
 Please refer to the [config file](../../../config/domino_etl.yaml) for more
 options.

--- a/physicsnemo_curator/run_etl.py
+++ b/physicsnemo_curator/run_etl.py
@@ -96,7 +96,6 @@ def main(cfg: DictConfig) -> None:
 
         wall_clock_time = time.time() - wall_clock_start
         logger.info("\nProcessing Summary:")
-        logger.info(f"Serialization method: {processing_config.serialization_method}")
         logger.info(f"Number of processes: {processing_config.num_processes}")
         logger.info(f"Total wall clock time: {wall_clock_time:.2f} seconds")
 

--- a/tests/test_etl/test_processing_config.py
+++ b/tests/test_etl/test_processing_config.py
@@ -24,20 +24,6 @@ def test_valid_minimal_config():
     """Test creation of ProcessingConfig with minimal valid parameters."""
     config = ProcessingConfig(num_processes=4)
     assert config.num_processes == 4
-    assert config.serialization_method == "numpy"
-    assert config.compression is None
-
-
-def test_valid_zarr_config():
-    """Test creation of ProcessingConfig with zarr and compression."""
-    config = ProcessingConfig(
-        num_processes=2,
-        serialization_method="zarr",
-        compression={"method": "zstd", "level": 3},
-    )
-    assert config.num_processes == 2
-    assert config.serialization_method == "zarr"
-    assert config.compression == {"method": "zstd", "level": 3}
 
 
 def test_invalid_num_processes_raises_value_error():
@@ -47,51 +33,3 @@ def test_invalid_num_processes_raises_value_error():
 
     with pytest.raises(ValueError, match="num_processes must be positive"):
         ProcessingConfig(num_processes=-1)
-
-
-def test_invalid_compression_with_numpy_raises_value_error():
-    """Test that compression with numpy serialization raises ValueError."""
-    with pytest.raises(ValueError, match="Compression is only supported with zarr"):
-        ProcessingConfig(
-            num_processes=1,
-            serialization_method="numpy",
-            compression={"method": "zstd", "level": 3},
-        )
-
-
-def test_invalid_compression_config_raises_value_error():
-    """Test that invalid compression configuration raises ValueError."""
-    # Missing required keys
-    with pytest.raises(ValueError, match="missing required keys"):
-        ProcessingConfig(
-            num_processes=1,
-            serialization_method="zarr",
-            compression={"method": "zstd"},  # missing level
-        )
-
-    # Invalid compression level type
-    with pytest.raises(ValueError, match="must be an integer between 1 and 9"):
-        ProcessingConfig(
-            num_processes=1,
-            serialization_method="zarr",
-            compression={"method": "zstd", "level": "3"},  # string instead of int
-        )
-
-    # Compression level out of range
-    with pytest.raises(ValueError, match="must be an integer between 1 and 9"):
-        ProcessingConfig(
-            num_processes=1,
-            serialization_method="zarr",
-            compression={"method": "zstd", "level": 10},
-        )
-
-
-def test_invalid_serialization_method_raises_value_error():
-    """Test that invalid serialization method raises ValueError."""
-    with pytest.raises(
-        ValueError, match="Serialization method must be either 'numpy' or 'zarr'"
-    ):
-        ProcessingConfig(
-            num_processes=1,
-            serialization_method="invalid",
-        )

--- a/tests/test_examples/test_external_aerodynamics/test_domino/test_config.py
+++ b/tests/test_examples/test_external_aerodynamics/test_domino/test_config.py
@@ -57,8 +57,6 @@ def test_domino_etl_config():
 
         # Test processing settings
         assert cfg.etl.processing.num_processes == 12
-        assert cfg.etl.processing.serialization_method == "zarr"
-        assert not cfg.etl.processing.compression
         assert cfg.etl.processing.args == {}
 
         # Test that we can actually create the validator
@@ -104,7 +102,6 @@ def test_domino_etl_config():
             instantiate(cfg.etl.sink)
             assert m.call_count == 1
         assert cfg.etl.sink.kind == "drivaerml"
-        assert cfg.etl.sink.serialization_method == "zarr"
         assert cfg.etl.sink.overwrite_existing is True
 
 
@@ -120,10 +117,6 @@ def test_config_validation():
 
         # Test that model_type is a valid ModelType
         assert cfg.etl.common.model_type in [m.value for m in ModelType]
-
-        # Test that serialization_method is valid
-        assert cfg.etl.processing.serialization_method in ["numpy", "zarr"]
-        assert cfg.etl.sink.serialization_method in ["numpy", "zarr"]
 
         # Test that validation_level is valid
         assert cfg.etl.validator.validation_level in ["structure", "fields"]

--- a/tests/test_examples/test_external_aerodynamics/test_domino/test_data_transformations.py
+++ b/tests/test_examples/test_external_aerodynamics/test_domino/test_data_transformations.py
@@ -109,9 +109,7 @@ class TestDoMINOZarrTransformation:
 
     def test_initialization(self):
         """Test initialization of Zarr transformation."""
-        config = ProcessingConfig(
-            num_processes=1, args={"compression_method": "zstd", "compression_level": 5}
-        )
+        config = ProcessingConfig(num_processes=1)
         transform = DoMINOZarrTransformation(config)
         assert transform.config == config
         assert transform.compressor.cname == "zstd"
@@ -121,8 +119,6 @@ class TestDoMINOZarrTransformation:
         """Test Zarr transformation of DoMINO data."""
         config = ProcessingConfig(
             num_processes=1,
-            serialization_method="zarr",
-            args={"compression_method": "zstd", "compression_level": 5},
         )
         transform = DoMINOZarrTransformation(config)
 
@@ -160,11 +156,7 @@ class TestDoMINOZarrTransformation:
 
     def test_prepare_array(self):
         """Test array preparation for Zarr storage."""
-        config = ProcessingConfig(
-            num_processes=1,
-            serialization_method="zarr",
-            args={"compression_method": "zstd", "compression_level": 5},
-        )
+        config = ProcessingConfig(num_processes=1)
         transform = DoMINOZarrTransformation(config)
 
         # Test 1D array
@@ -195,11 +187,7 @@ class TestDoMINOZarrTransformation:
     )
     def test_chunk_size_warnings(self, chunk_size_mb, should_warn):
         """Test warnings for different chunk sizes."""
-        config = ProcessingConfig(
-            num_processes=1,
-            serialization_method="zarr",
-            args={"compression_method": "zstd", "compression_level": 5},
-        )
+        config = ProcessingConfig(num_processes=1)
 
         with warnings.catch_warnings(record=True) as w:
             # Cause all warnings to always be triggered
@@ -235,11 +223,7 @@ class TestDoMINOZarrTransformation:
             volume_fields=sample_data.volume_fields,
         )
 
-        config = ProcessingConfig(
-            num_processes=1,
-            serialization_method="zarr",
-            args={"compression_method": "zstd", "compression_level": 5},
-        )
+        config = ProcessingConfig(num_processes=1)
 
         # Create transformations with different chunk sizes
         transform_small = DoMINOZarrTransformation(config, chunk_size_mb=1.0)


### PR DESCRIPTION
Why?
- ProcessingConfig should be general for many Physics/AI ETL pipelines. The current config was too specific to the DoMINO pipeline

What?
- Removed serialization specific config from base ProcessingConfig
- They still exist in the DoMINO specific config (transformation and sink)
- Additionally, added documentation about how to change the serialization method