### PR TITLE
Allow custom transformations for DoMINO

### DIFF
--- a/examples/config/domino_etl.yaml
+++ b/examples/config/domino_etl.yaml
@@ -60,6 +60,8 @@ etl:
     # Users can choose between DoMINOZarrTransformation or DoMINONumpyTransformation.
     # NOTE: This should match the Sink class' serialization method.
     # If you choose the NumPy transformation, please comment out the Zarr transformation, and uncomment the below NumPy transformation.
+
+    # TODO (@saikrishnanc): Use Hydra facilities to avoid having to edit the config in multiple places.
     zarr:
       _target_: examples.external_aerodynamics.domino.data_transformations.DoMINOZarrTransformation
       _convert_: all

--- a/examples/config/domino_etl.yaml
+++ b/examples/config/domino_etl.yaml
@@ -42,21 +42,31 @@ etl:
     kind: ${etl.common.kind}
     model_type: ${etl.common.model_type}
 
-    decimation:
-      algo: decimate_pro  # can be one of {decimate_pro, decimate}
-      reduction: 0.0  # 0 means no decimation.
-      preserve_topology: false
-
   transformations:
-    # User can choose which transformations to use, for example,
-    # DoMINOZarrTransformation or DoMINONumpyTransformation.
+
+    # Preprocessing transformations.
+    # These take in the raw geometry, volume and surface data, and apply DoMINO specific preprocessing transformations.
+    # Variable names are piped in from the variables/drivaerml.yaml or variables/ahmedml.yaml file.
+    preprocessing:
+      _target_: examples.external_aerodynamics.domino.data_transformations.DoMINOPreprocessingTransformation
+      _convert_: all
+      decimation:
+        algo: decimate_pro  # can be one of {decimate_pro, decimate}
+        reduction: 0.0  # 0 means no decimation.
+        preserve_topology: false
+
+    # Default - Zarr transformation.
+    # This takes in the processed data and metadata, and converts it into a Zarr/NumPy write ready format.
+    # Users can choose between DoMINOZarrTransformation or DoMINONumpyTransformation.
     # NOTE: This should match the Sink class' serialization method.
+    # If you choose the NumPy transformation, please comment out the Zarr transformation, and uncomment the below NumPy transformation.
     zarr:
       _target_: examples.external_aerodynamics.domino.data_transformations.DoMINOZarrTransformation
       _convert_: all
       compression_method: "zstd"
       compression_level: 5
       chunk_size_mb: 1.0
+
     # numpy:
     #   _target_: examples.external_aerodynamics.domino.data_transformations.DoMINONumpyTransformation
     #   _convert_: all

--- a/examples/config/variables/ahmedml.yaml
+++ b/examples/config/variables/ahmedml.yaml
@@ -1,4 +1,4 @@
-# @package etl.source
+# @package etl.transformations.preprocessing
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 # SPDX-FileCopyrightText: All rights reserved.
 # SPDX-License-Identifier: Apache-2.0

--- a/examples/config/variables/drivaerml.yaml
+++ b/examples/config/variables/drivaerml.yaml
@@ -1,4 +1,4 @@
-# @package etl.source
+# @package etl.transformations.preprocessing
 # SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 # SPDX-FileCopyrightText: All rights reserved.
 # SPDX-License-Identifier: Apache-2.0

--- a/examples/external_aerodynamics/domino/README.md
+++ b/examples/external_aerodynamics/domino/README.md
@@ -166,7 +166,7 @@ This is already demonstrated in [domino_etl.yaml](../../../examples/config/domin
 where `DoMINOPreprocessingTransformation` is applied followed by `DoMINOZarrTransformation`.
 
 Please use these guidelines to create your own ETL pipeline to train a DoMINO model
-on a different dataset or on a non external aerdoynamics application!
+on a different dataset or on a non external aerodynamics application!
 
 ### Model Training
 

--- a/examples/external_aerodynamics/domino/README.md
+++ b/examples/external_aerodynamics/domino/README.md
@@ -156,6 +156,18 @@ For more details on the decimation algorithms and their parameters, refer to:
 Volume meshes are not supported, and in case of `combined` model type,
 only the surface part will be decimated.
 
+### Custom Transformations
+
+This ETL pipeline is intended to be configurable. As such, you can extend it in the following ways:
+
+- Create your own transformation (use [data_transformations.py](./data_transformations.py) as a template)
+- Stack multiple transformations on top of each other.
+This is already demonstrated in [domino_etl.yaml](../../../examples/config/domino_etl.yaml),
+where `DoMINOPreprocessingTransformation` is applied followed by `DoMINOZarrTransformation`.
+
+Please use these guidelines to create your own ETL pipeline to train a DoMINO model
+on a different dataset or on a non external aerdoynamics application!
+
 ### Model Training
 
 Train your DoMINO Model on your own data by following the [example in PhysicsNeMo](https://github.com/NVIDIA/physicsnemo/tree/main/examples/cfd/external_aerodynamics/domino)!

--- a/examples/external_aerodynamics/domino/data_sources.py
+++ b/examples/external_aerodynamics/domino/data_sources.py
@@ -108,6 +108,7 @@ class DoMINODataSource(DataSource):
             if not volume_path.exists():
                 raise FileNotFoundError(f"Volume data file not found: {volume_path}")
 
+            # TODO (@saikrishnanc): Use pyvista to read the volume data.
             reader = vtk.vtkXMLUnstructuredGridReader()
             reader.SetFileName(str(volume_path))
             reader.Update()

--- a/examples/external_aerodynamics/domino/data_sources.py
+++ b/examples/external_aerodynamics/domino/data_sources.py
@@ -15,10 +15,9 @@
 # limitations under the License.
 
 import shutil
-import warnings
 from dataclasses import asdict
 from pathlib import Path
-from typing import Any, Optional
+from typing import Optional
 
 import numpy as np
 import pyvista as pv
@@ -28,8 +27,7 @@ import zarr
 from physicsnemo_curator.etl.data_sources import DataSource
 from physicsnemo_curator.etl.processing_config import ProcessingConfig
 
-from .constants import DatasetKind, ModelType, PhysicsConstants
-from .domino_utils import get_volume_data, to_float32
+from .constants import DatasetKind, ModelType
 from .paths import get_path_getter
 from .schemas import (
     DoMINOExtractedDataInMemory,
@@ -42,48 +40,26 @@ from .schemas import (
 class DoMINODataSource(DataSource):
     """Data source for reading and writing DoMINO simulation data."""
 
-    DECIMATION_ALGOS: tuple[str, ...] = ("decimate_pro", "decimate")
-
     def __init__(
         self,
         cfg: ProcessingConfig,
         input_dir: Optional[Path] = None,
         output_dir: Optional[Path] = None,
         kind: DatasetKind | str = DatasetKind.DRIVAERML,
-        surface_variables: Optional[dict[str, str]] = None,
-        volume_variables: Optional[dict[str, str]] = None,
         model_type: Optional[ModelType | str] = None,
         serialization_method: str = "numpy",
         overwrite_existing: bool = True,
-        decimation: Optional[dict[str, Any]] = None,
     ):
         super().__init__(cfg)
 
         self.input_dir = Path(input_dir) if input_dir else None
         self.output_dir = Path(output_dir) if output_dir else None
         self.kind = DatasetKind(kind.lower()) if isinstance(kind, str) else kind
-        self.surface_variables = surface_variables
-        self.volume_variables = volume_variables
         self.model_type = (
             ModelType(model_type.lower()) if isinstance(model_type, str) else None
         )
         self.serialization_method = serialization_method
         self.overwrite_existing = overwrite_existing
-
-        self.decimation_algo = None
-        self.target_reduction = None
-        if decimation is not None:
-            self.decimation_algo = decimation.pop("algo")
-            if self.decimation_algo not in self.DECIMATION_ALGOS:
-                raise ValueError(
-                    f"Unsupported decimation algo {self.decimation_algo}, must be one of {', '.join(self.DECIMATION_ALGOS)}"
-                )
-            self.target_reduction = decimation.pop("reduction", 0.0)
-            if not 0 <= self.target_reduction < 1.0:
-                raise ValueError(
-                    f"Expected value in [0, 1), got {self.target_reduction}"
-                )
-            self.decimation_kwargs = dict(decimation)
 
         # Validate directories based on read/write usage
         if self.input_dir and not self.input_dir.exists():
@@ -92,7 +68,6 @@ class DoMINODataSource(DataSource):
             self.output_dir.mkdir(parents=True, exist_ok=True)
 
         self.path_getter = get_path_getter(kind)
-        self.constants = PhysicsConstants()
 
     def get_file_list(self) -> list[str]:
         """Get list of simulation directories to process."""
@@ -121,27 +96,11 @@ class DoMINODataSource(DataSource):
             raise FileNotFoundError(f"STL file not found: {stl_path}")
 
         reader = pv.get_reader(str(stl_path))
-        mesh_stl = reader.read()
-
-        bounds = mesh_stl.bounds
-        stl_vertices = mesh_stl.points
-        stl_faces = np.array(mesh_stl.faces).reshape((-1, 4))[
-            :, 1:
-        ]  # Assuming triangular elements
-        mesh_indices_flattened = stl_faces.flatten()
-        stl_sizes = mesh_stl.compute_cell_sizes(length=False, area=True, volume=False)
-        stl_sizes = np.array(stl_sizes.cell_data["Area"])
-        stl_centers = np.array(mesh_stl.cell_centers().points)
-
-        length_scale = np.amax(np.amax(stl_vertices, 0) - np.amin(stl_vertices, 0))
+        stl_polydata = reader.read()
 
         # Initialize volume and surface data
-        volume_fields = None
-        volume_coordinates = None
-        surface_fields = None
-        surface_coordinates = None
-        surface_normals = None
-        surface_sizes = None
+        surface_polydata = None
+        volume_unstructured_grid = None
 
         # Load volume data if needed
         if self.model_type in [ModelType.VOLUME, ModelType.COMBINED]:
@@ -152,12 +111,7 @@ class DoMINODataSource(DataSource):
             reader = vtk.vtkXMLUnstructuredGridReader()
             reader.SetFileName(str(volume_path))
             reader.Update()
-            polydata = reader.GetOutput()
-
-            # Process volume data
-            volume_coordinates, volume_fields = self._process_volume_data(
-                polydata, length_scale
-            )
+            volume_unstructured_grid = reader.GetOutput()
 
         # Load surface data if needed
         if self.model_type in [ModelType.SURFACE, ModelType.COMBINED]:
@@ -165,121 +119,19 @@ class DoMINODataSource(DataSource):
             if not surface_path.exists():
                 raise FileNotFoundError(f"Surface data file not found: {surface_path}")
 
-            # Process surface data
-            (
-                surface_coordinates,
-                surface_normals,
-                surface_sizes,
-                surface_fields,
-            ) = self._process_surface_data(surface_path)
+            surface_polydata = pv.read(surface_path)
 
         metadata = DoMINOMetadata(
             filename=dirname,
-            stream_velocity=self.constants.STREAM_VELOCITY,
-            air_density=self.constants.AIR_DENSITY,
-            x_bound=bounds[0:2],  # xmin, xmax
-            y_bound=bounds[2:4],  # ymin, ymax
-            z_bound=bounds[4:6],  # zmin, zmax
             dataset_type=self.model_type,  # surface, volume, combined
-            num_points=len(mesh_stl.points),
-            num_faces=len(mesh_indices_flattened),
-            decimation_reduction=self.target_reduction,
-            decimation_algo=self.decimation_algo,
         )
 
         return DoMINOExtractedDataInMemory(
-            stl_coordinates=to_float32(stl_vertices),
-            stl_centers=to_float32(stl_centers),
-            stl_faces=to_float32(mesh_indices_flattened),
-            stl_areas=to_float32(stl_sizes),
-            surface_mesh_centers=to_float32(surface_coordinates),
-            surface_normals=to_float32(surface_normals),
-            surface_areas=to_float32(surface_sizes),
-            volume_fields=to_float32(volume_fields),
-            volume_mesh_centers=to_float32(volume_coordinates),
-            surface_fields=to_float32(surface_fields),
+            stl_polydata=stl_polydata,
+            surface_polydata=surface_polydata,
+            volume_unstructured_grid=volume_unstructured_grid,
             metadata=metadata,
         )
-
-    def _process_volume_data(self, polydata, length_scale):
-        """Process volume mesh data."""
-
-        volume_coordinates, volume_fields = get_volume_data(
-            polydata, self.volume_variables
-        )
-        volume_fields = np.concatenate(volume_fields, axis=-1)
-
-        # Non-dimensionalize volume fields
-        volume_fields[:, :3] = volume_fields[:, :3] / self.constants.STREAM_VELOCITY
-        volume_fields[:, 3:4] = volume_fields[:, 3:4] / (
-            self.constants.AIR_DENSITY * self.constants.STREAM_VELOCITY**2.0
-        )
-        volume_fields[:, 4:] = volume_fields[:, 4:] / (
-            self.constants.STREAM_VELOCITY * length_scale
-        )
-
-        return volume_coordinates, volume_fields
-
-    def _process_surface_data(self, filename: Path):
-        """Process surface mesh data."""
-
-        mesh = pv.read(filename)
-
-        # Decimate mesh if needed.
-        mesh = self._decimate_mesh(mesh)
-
-        cell_data = (mesh.cell_data[k] for k in self.surface_variables)
-        surface_fields = np.concatenate(
-            [d if d.ndim > 1 else d[:, np.newaxis] for d in cell_data], axis=-1
-        )
-        surface_coordinates = np.array(mesh.cell_centers().points)
-        surface_normals = np.array(mesh.cell_normals)
-        surface_sizes = mesh.compute_cell_sizes(length=False, area=True, volume=False)
-        surface_sizes = np.array(surface_sizes.cell_data["Area"])
-
-        # Normalize cell normals
-        surface_normals = (
-            surface_normals / np.linalg.norm(surface_normals, axis=1)[:, np.newaxis]
-        )
-
-        # Non-dimensionalize surface fields
-        surface_fields = surface_fields / (
-            self.constants.AIR_DENSITY * self.constants.STREAM_VELOCITY**2.0
-        )
-
-        return surface_coordinates, surface_normals, surface_sizes, surface_fields
-
-    def _decimate_mesh(self, mesh: pv.PolyData):
-        """Decimate source mesh."""
-
-        if not (self.decimation_algo is not None and self.target_reduction > 0):
-            return mesh
-
-        # Need point_data to interpolate target mesh node values.
-        mesh = mesh.cell_data_to_point_data()
-        # Decimation algos require tri-mesh.
-        mesh = mesh.triangulate()
-        match self.decimation_algo:
-            case "decimate_pro":
-                mesh = mesh.decimate_pro(
-                    self.target_reduction, **self.decimation_kwargs
-                )
-            case "decimate":
-                if mesh.n_points > 400_000:
-                    warnings.warn(
-                        "decimate algo may hang on meshes of size more than 400K"
-                    )
-                mesh = mesh.decimate(
-                    self.target_reduction,
-                    attribute_error=True,
-                    scalars=True,
-                    vectors=True,
-                    **self.decimation_kwargs,
-                )
-            case _:
-                raise ValueError(f"Unsupported decimation algo {self.algo}")
-        # Compute cell data.
-        return mesh.point_data_to_cell_data()
 
     def write(
         self,

--- a/examples/external_aerodynamics/domino/data_transformations.py
+++ b/examples/external_aerodynamics/domino/data_transformations.py
@@ -107,7 +107,9 @@ class DoMINOPreprocessingTransformation(DataTransformation):
                     f"Expected value in [0, 1), got {self.target_reduction}"
                 )
             # Copy decimation dict, excluding 'algo' and 'reduction'
-            self.decimation_kwargs = {k: v for k, v in decimation.items() if k not in ("algo", "reduction")}
+            self.decimation_kwargs = {
+                k: v for k, v in decimation.items() if k not in ("algo", "reduction")
+            }
 
         self.constants = PhysicsConstants()
 

--- a/examples/external_aerodynamics/domino/data_transformations.py
+++ b/examples/external_aerodynamics/domino/data_transformations.py
@@ -96,17 +96,18 @@ class DoMINOPreprocessingTransformation(DataTransformation):
         self.decimation_algo = None
         self.target_reduction = None
         if decimation is not None:
-            self.decimation_algo = decimation.pop("algo")
+            self.decimation_algo = decimation.get("algo")
             if self.decimation_algo not in self.DECIMATION_ALGOS:
                 raise ValueError(
                     f"Unsupported decimation algo {self.decimation_algo}, must be one of {', '.join(self.DECIMATION_ALGOS)}"
                 )
-            self.target_reduction = decimation.pop("reduction", 0.0)
+            self.target_reduction = decimation.get("reduction", 0.0)
             if not 0 <= self.target_reduction < 1.0:
                 raise ValueError(
                     f"Expected value in [0, 1), got {self.target_reduction}"
                 )
-            self.decimation_kwargs = dict(decimation)
+            # Copy decimation dict, excluding 'algo' and 'reduction'
+            self.decimation_kwargs = {k: v for k, v in decimation.items() if k not in ("algo", "reduction")}
 
         self.constants = PhysicsConstants()
 

--- a/examples/external_aerodynamics/domino/data_transformations.py
+++ b/examples/external_aerodynamics/domino/data_transformations.py
@@ -15,14 +15,18 @@
 # limitations under the License.
 
 import warnings
+from typing import Any, Optional
 
 import numpy as np
+import pyvista as pv
+import vtk
 from numcodecs import Blosc
 
 from physicsnemo_curator.etl.data_transformations import DataTransformation
 from physicsnemo_curator.etl.processing_config import ProcessingConfig
 
-from .domino_utils import to_float32
+from .constants import PhysicsConstants
+from .domino_utils import decimate_mesh, get_volume_data, to_float32
 from .schemas import (
     DoMINOExtractedDataInMemory,
     DoMINONumpyDataInMemory,
@@ -70,6 +74,173 @@ class DoMINONumpyTransformation(DataTransformation):
             volume_mesh_centers=to_float32(data.volume_mesh_centers),
             volume_fields=to_float32(data.volume_fields),
         )
+
+
+class DoMINOPreprocessingTransformation(DataTransformation):
+    """General preprocessing of data for DoMINO model."""
+
+    DECIMATION_ALGOS: tuple[str, ...] = ("decimate_pro", "decimate")
+
+    def __init__(
+        self,
+        cfg: ProcessingConfig,
+        surface_variables: Optional[dict[str, str]] = None,
+        volume_variables: Optional[dict[str, str]] = None,
+        decimation: Optional[dict[str, Any]] = None,
+    ):
+        super().__init__(cfg)
+
+        self.surface_variables = surface_variables
+        self.volume_variables = volume_variables
+
+        self.decimation_algo = None
+        self.target_reduction = None
+        if decimation is not None:
+            self.decimation_algo = decimation.pop("algo")
+            if self.decimation_algo not in self.DECIMATION_ALGOS:
+                raise ValueError(
+                    f"Unsupported decimation algo {self.decimation_algo}, must be one of {', '.join(self.DECIMATION_ALGOS)}"
+                )
+            self.target_reduction = decimation.pop("reduction", 0.0)
+            if not 0 <= self.target_reduction < 1.0:
+                raise ValueError(
+                    f"Expected value in [0, 1), got {self.target_reduction}"
+                )
+            self.decimation_kwargs = dict(decimation)
+
+        self.constants = PhysicsConstants()
+
+    def transform(
+        self, data: DoMINOExtractedDataInMemory
+    ) -> DoMINOExtractedDataInMemory:
+        """Transform data for preprocessing."""
+
+        # Process STL data
+        mesh_stl = data.stl_polydata
+        stl_vertices = mesh_stl.points
+        stl_faces = np.array(mesh_stl.faces).reshape((-1, 4))[
+            :, 1:
+        ]  # Assuming triangular elements
+        mesh_indices_flattened = stl_faces.flatten()
+        stl_sizes = mesh_stl.compute_cell_sizes(length=False, area=True, volume=False)
+        stl_sizes = np.array(stl_sizes.cell_data["Area"])
+        stl_centers = np.array(mesh_stl.cell_centers().points)
+
+        # Delete raw STL data to save memory
+        data.stl_polydata = None
+
+        # Update processed STL data
+        data.stl_coordinates = to_float32(stl_vertices)
+        data.stl_centers = to_float32(stl_centers)
+        data.stl_faces = to_float32(mesh_indices_flattened)
+        data.stl_areas = to_float32(stl_sizes)
+
+        # Update metadata
+        bounds = mesh_stl.bounds
+        data.metadata.x_bound = bounds[0:2]  # xmin, xmax
+        data.metadata.y_bound = bounds[2:4]  # ymin, ymax
+        data.metadata.z_bound = bounds[4:6]  # zmin, zmax
+        data.metadata.num_points = len(mesh_stl.points)
+        data.metadata.num_faces = len(mesh_indices_flattened)
+        data.metadata.stream_velocity = self.constants.STREAM_VELOCITY
+        data.metadata.air_density = self.constants.AIR_DENSITY
+
+        # Load volume data if needed
+        if data.volume_unstructured_grid is not None:
+            # Process volume data
+            length_scale = np.amax(np.amax(stl_vertices, 0) - np.amin(stl_vertices, 0))
+            volume_coordinates, volume_fields = self._process_volume_data(
+                data.volume_unstructured_grid, length_scale
+            )
+
+            # Delete raw volume data to save memory
+            data.volume_unstructured_grid = None
+
+            # Update processed volume data
+            data.volume_mesh_centers = to_float32(volume_coordinates)
+            data.volume_fields = to_float32(volume_fields)
+
+        if data.surface_polydata is not None:
+
+            # Process surface data
+            (
+                surface_coordinates,
+                surface_normals,
+                surface_sizes,
+                surface_fields,
+            ) = self._process_surface_data(data.surface_polydata)
+
+            # Delete raw surface data to save memory
+            data.surface_polydata = None
+
+            # Update processed surface data
+            data.surface_mesh_centers = to_float32(surface_coordinates)
+            data.surface_normals = to_float32(surface_normals)
+            data.surface_areas = to_float32(surface_sizes)
+            data.surface_fields = to_float32(surface_fields)
+
+            # Update metadata
+            data.metadata.decimation_algo = self.decimation_algo
+            data.metadata.decimation_reduction = self.target_reduction
+
+        return data
+
+    def _process_volume_data(
+        self, unstructured_grid: vtk.vtkUnstructuredGrid, length_scale: float
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Process volume mesh data."""
+
+        volume_coordinates, volume_fields = get_volume_data(
+            unstructured_grid, self.volume_variables
+        )
+        volume_fields = np.concatenate(volume_fields, axis=-1)
+
+        # Non-dimensionalize volume fields
+        volume_fields[:, :3] = volume_fields[:, :3] / self.constants.STREAM_VELOCITY
+        volume_fields[:, 3:4] = volume_fields[:, 3:4] / (
+            self.constants.AIR_DENSITY * self.constants.STREAM_VELOCITY**2.0
+        )
+        volume_fields[:, 4:] = volume_fields[:, 4:] / (
+            self.constants.STREAM_VELOCITY * length_scale
+        )
+
+        return volume_coordinates, volume_fields
+
+    def _process_surface_data(
+        self,
+        mesh: pv.PolyData,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """Process surface mesh data."""
+
+        # Decimate mesh if needed.
+        if self.decimation_algo is not None and self.target_reduction > 0:
+            mesh = decimate_mesh(
+                mesh,
+                self.decimation_algo,
+                self.target_reduction,
+                self.decimation_kwargs,
+            )
+
+        cell_data = (mesh.cell_data[k] for k in self.surface_variables)
+        surface_fields = np.concatenate(
+            [d if d.ndim > 1 else d[:, np.newaxis] for d in cell_data], axis=-1
+        )
+        surface_coordinates = np.array(mesh.cell_centers().points)
+        surface_normals = np.array(mesh.cell_normals)
+        surface_sizes = mesh.compute_cell_sizes(length=False, area=True, volume=False)
+        surface_sizes = np.array(surface_sizes.cell_data["Area"])
+
+        # Normalize cell normals
+        surface_normals = (
+            surface_normals / np.linalg.norm(surface_normals, axis=1)[:, np.newaxis]
+        )
+
+        # Non-dimensionalize surface fields
+        surface_fields = surface_fields / (
+            self.constants.AIR_DENSITY * self.constants.STREAM_VELOCITY**2.0
+        )
+
+        return surface_coordinates, surface_normals, surface_sizes, surface_fields
 
 
 class DoMINOZarrTransformation(DataTransformation):

--- a/examples/external_aerodynamics/domino/domino_utils.py
+++ b/examples/external_aerodynamics/domino/domino_utils.py
@@ -18,9 +18,11 @@
 Utilities for processing DoMINO data.
 """
 
+import warnings
 from typing import Optional, TypeAlias
 
 import numpy as np
+import pyvista as pv
 import vtk
 from vtk.util import numpy_support
 
@@ -79,3 +81,36 @@ def get_volume_data(polydata, variables):
     fields = get_fields(point_data, variables)
 
     return vertices, fields
+
+
+def decimate_mesh(
+    mesh: pv.PolyData,
+    algo: str,
+    reduction: float,
+    kwargs: dict,
+) -> pv.PolyData:
+    """Decimate mesh using pyvista."""
+
+    # Need point_data to interpolate target mesh node values.
+    mesh = mesh.cell_data_to_point_data()
+
+    # Decimation algos require tri-mesh.
+    mesh = mesh.triangulate()
+    match algo:
+        case "decimate_pro":
+            mesh = mesh.decimate_pro(reduction, **kwargs)
+        case "decimate":
+            if mesh.n_points > 400_000:
+                warnings.warn("decimate algo may hang on meshes of size more than 400K")
+            mesh = mesh.decimate(
+                reduction,
+                attribute_error=True,
+                scalars=True,
+                vectors=True,
+                **kwargs,
+            )
+        case _:
+            raise ValueError(f"Unsupported decimation algo {algo}")
+
+    # Compute cell data.
+    return mesh.point_data_to_cell_data()

--- a/examples/external_aerodynamics/domino/schemas.py
+++ b/examples/external_aerodynamics/domino/schemas.py
@@ -47,8 +47,8 @@ class DoMINOMetadata:
     z_bound: Optional[tuple[float, float]] = None  # zmin, zmax
 
     # Mesh statistics
-    num_points: int = None
-    num_faces: int = None
+    num_points: Optional[int] = None
+    num_faces: Optional[int] = None
 
     # Processing parameters
     decimation_reduction: Optional[float] = None

--- a/examples/external_aerodynamics/domino/schemas.py
+++ b/examples/external_aerodynamics/domino/schemas.py
@@ -74,10 +74,10 @@ class DoMINOExtractedDataInMemory:
     volume_unstructured_grid: Optional[vtk.vtkUnstructuredGrid] = None
 
     # Processed geometry data
-    stl_coordinates: np.ndarray = None
-    stl_centers: np.ndarray = None
-    stl_faces: np.ndarray = None
-    stl_areas: np.ndarray = None
+    stl_coordinates: Optional[np.ndarray] = None
+    stl_centers: Optional[np.ndarray] = None
+    stl_faces: Optional[np.ndarray] = None
+    stl_areas: Optional[np.ndarray] = None
 
     # Processed surface data
     surface_mesh_centers: Optional[np.ndarray] = None

--- a/examples/external_aerodynamics/domino/schemas.py
+++ b/examples/external_aerodynamics/domino/schemas.py
@@ -19,11 +19,13 @@ from typing import Optional
 
 import numcodecs
 import numpy as np
+import pyvista as pv
+import vtk
 
 from .constants import ModelType
 
 
-@dataclass(frozen=True)
+@dataclass
 class DoMINOMetadata:
     """Metadata for DoMINO simulation data.
 
@@ -36,48 +38,54 @@ class DoMINOMetadata:
     dataset_type: ModelType
 
     # Physical parameters
-    stream_velocity: float
-    air_density: float
+    stream_velocity: Optional[float] = None
+    air_density: Optional[float] = None
 
     # Geometry bounds
-    x_bound: tuple[float, float]
-    y_bound: tuple[float, float]
-    z_bound: tuple[float, float]
+    x_bound: tuple[float, float] = None  # xmin, xmax
+    y_bound: tuple[float, float] = None  # ymin, ymax
+    z_bound: tuple[float, float] = None  # zmin, zmax
 
     # Mesh statistics
-    num_points: int
-    num_faces: int
+    num_points: int = None
+    num_faces: int = None
 
     # Processing parameters
     decimation_reduction: Optional[float] = None
     decimation_algo: Optional[str] = None
 
 
-@dataclass(frozen=True)
+@dataclass
 class DoMINOExtractedDataInMemory:
     """Container for DoMINO data and metadata extracted from the simulation.
     This is the in memory data structure.
 
     Version history:
     - 1.0: Initial version of data for training DoMINO.
+    - 2.0: This can contain raw data and processed data.
     """
 
     # Metadata
     metadata: DoMINOMetadata
 
-    # Geometry data
-    stl_coordinates: np.ndarray
-    stl_centers: np.ndarray
-    stl_faces: np.ndarray
-    stl_areas: np.ndarray
+    # Raw data
+    stl_polydata: Optional[pv.PolyData] = None
+    surface_polydata: Optional[pv.PolyData] = None
+    volume_unstructured_grid: Optional[vtk.vtkUnstructuredGrid] = None
 
-    # Surface data
+    # Processed geometry data
+    stl_coordinates: np.ndarray = None
+    stl_centers: np.ndarray = None
+    stl_faces: np.ndarray = None
+    stl_areas: np.ndarray = None
+
+    # Processed surface data
     surface_mesh_centers: Optional[np.ndarray] = None
     surface_normals: Optional[np.ndarray] = None
     surface_areas: Optional[np.ndarray] = None
     surface_fields: Optional[np.ndarray] = None
 
-    # Volume data
+    # Processed volume data
     volume_mesh_centers: Optional[np.ndarray] = None
     volume_fields: Optional[np.ndarray] = None
 

--- a/examples/external_aerodynamics/domino/schemas.py
+++ b/examples/external_aerodynamics/domino/schemas.py
@@ -42,9 +42,9 @@ class DoMINOMetadata:
     air_density: Optional[float] = None
 
     # Geometry bounds
-    x_bound: tuple[float, float] = None  # xmin, xmax
-    y_bound: tuple[float, float] = None  # ymin, ymax
-    z_bound: tuple[float, float] = None  # zmin, zmax
+    x_bound: Optional[tuple[float, float]] = None  # xmin, xmax
+    y_bound: Optional[tuple[float, float]] = None  # ymin, ymax
+    z_bound: Optional[tuple[float, float]] = None  # zmin, zmax
 
     # Mesh statistics
     num_points: int = None

--- a/tests/test_examples/test_config.py
+++ b/tests/test_examples/test_config.py
@@ -76,23 +76,33 @@ def test_domino_etl_config():
             assert m.call_count == 1
         assert cfg.etl.source.kind == "drivaerml"
         assert cfg.etl.source.model_type == "surface"
-        assert cfg.etl.source.volume_variables == {
+        assert cfg.etl.transformations.preprocessing.volume_variables == {
             "UMeanTrim": "vector",
             "pMeanTrim": "scalar",
             "nutMeanTrim": "scalar",
         }
-        assert cfg.etl.source.surface_variables == {
+        assert cfg.etl.transformations.preprocessing.surface_variables == {
             "pMeanTrim": "scalar",
             "wallShearStressMeanTrim": "vector",
         }
 
         # Test transformation settings
+        # Test preprocessing transformation
+        with patch.object(
+            data_transformations.DoMINOPreprocessingTransformation,
+            "__init__",
+            return_value=None,
+        ) as m:
+            instantiate(cfg.etl.transformations.preprocessing)
+            assert m.call_count == 1
+
+        # Test zarr transformation
         with patch.object(
             data_transformations.DoMINOZarrTransformation,
             "__init__",
             return_value=None,
         ) as m:
-            instantiate(cfg.etl.transformations)
+            instantiate(cfg.etl.transformations.zarr)
             assert m.call_count == 1
 
         # Test sink settings

--- a/tests/test_examples/test_external_aerodynamics/test_domino/test_data_transformations.py
+++ b/tests/test_examples/test_external_aerodynamics/test_domino/test_data_transformations.py
@@ -360,7 +360,7 @@ class TestDoMINOPreprocessingTransformation:
     def test_initialization_invalid_reduction(self):
         """Test initialization with invalid reduction value."""
         config = ProcessingConfig(num_processes=1)
-        with pytest.raises(ValueError, match="Expected value in \\[0, 1\\)"):
+        with pytest.raises(ValueError, match="Expected value in \[0, 1\)"):
             DoMINOPreprocessingTransformation(
                 config,
                 decimation={"algo": "decimate_pro", "reduction": 1.5},

--- a/tests/test_examples/test_external_aerodynamics/test_domino/test_data_transformations.py
+++ b/tests/test_examples/test_external_aerodynamics/test_domino/test_data_transformations.py
@@ -14,7 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import shutil
+import tempfile
 import warnings
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -22,8 +25,13 @@ import pytest
 from examples.external_aerodynamics.domino.constants import (
     ModelType,
 )
+from examples.external_aerodynamics.domino.data_sources import (
+    DatasetKind,
+    DoMINODataSource,
+)
 from examples.external_aerodynamics.domino.data_transformations import (
     DoMINONumpyTransformation,
+    DoMINOPreprocessingTransformation,
     DoMINOZarrTransformation,
 )
 from examples.external_aerodynamics.domino.schemas import (
@@ -35,10 +43,51 @@ from examples.external_aerodynamics.domino.schemas import (
 )
 from physicsnemo_curator.etl.processing_config import ProcessingConfig
 
+from .utils import create_mock_stl, create_mock_surface_vtk, create_mock_volume_vtk
+
 
 @pytest.fixture
-def sample_data():
-    """Create sample DoMINO data for testing."""
+def temp_dir():
+    """Create a temporary directory for test data."""
+    temp_dir = tempfile.mkdtemp()
+    yield Path(temp_dir)
+    shutil.rmtree(temp_dir)
+
+
+@pytest.fixture
+def sample_data_raw(temp_dir):
+    """Create sample Raw DrivAerML data for testing."""
+
+    case_dir = temp_dir / "run_001"
+    case_dir.mkdir(parents=True, exist_ok=True)
+
+    # Create STL file with correct name and path
+    stl_path = case_dir / "drivaer_001.stl"
+    stl_path.parent.mkdir(parents=True, exist_ok=True)
+    create_mock_stl(stl_path)
+
+    # Create VTK files with correct paths
+    vtk_path = case_dir
+    vtk_path.mkdir(parents=True, exist_ok=True)
+    create_mock_surface_vtk(vtk_path / "boundary_001.vtp")  # Updated surface file name
+    create_mock_volume_vtk(vtk_path / "volume_001.vtu")  # Updated volume file name
+
+    config = ProcessingConfig(num_processes=1)
+    source = DoMINODataSource(
+        config,
+        input_dir=case_dir.parent,
+        kind=DatasetKind.DRIVAERML,
+        model_type=ModelType.COMBINED,
+    )
+
+    data = source.read_file("run_001")
+
+    return data
+
+
+@pytest.fixture
+def sample_data_processed():
+    """Create sample processed DoMINO data for testing."""
     return DoMINOExtractedDataInMemory(
         metadata=DoMINOMetadata(
             filename="run_1234",
@@ -75,33 +124,35 @@ class TestDoMINONumpyTransformation:
         transform = DoMINONumpyTransformation(config)
         assert transform.config == config
 
-    def test_transform(self, sample_data):
+    def test_transform(self, sample_data_processed):
         """Test NumPy transformation of DoMINO data."""
         config = ProcessingConfig(num_processes=1)
         transform = DoMINONumpyTransformation(config)
 
-        result = transform.transform(sample_data)
+        result = transform.transform(sample_data_processed)
         assert isinstance(result, DoMINONumpyDataInMemory)
 
         # Check a couple of STL fields
         np.testing.assert_array_equal(
-            result.stl_coordinates, sample_data.stl_coordinates
+            result.stl_coordinates, sample_data_processed.stl_coordinates
         )
-        np.testing.assert_array_equal(result.stl_areas, sample_data.stl_areas)
+        np.testing.assert_array_equal(result.stl_areas, sample_data_processed.stl_areas)
 
         # Check a couple of surface fields
         np.testing.assert_array_equal(
-            result.surface_mesh_centers, sample_data.surface_mesh_centers
+            result.surface_mesh_centers, sample_data_processed.surface_mesh_centers
         )
         np.testing.assert_array_equal(
-            result.surface_normals, sample_data.surface_normals
+            result.surface_normals, sample_data_processed.surface_normals
         )
 
         # Check a couple of volume fields
         np.testing.assert_array_equal(
-            result.volume_mesh_centers, sample_data.volume_mesh_centers
+            result.volume_mesh_centers, sample_data_processed.volume_mesh_centers
         )
-        np.testing.assert_array_equal(result.volume_fields, sample_data.volume_fields)
+        np.testing.assert_array_equal(
+            result.volume_fields, sample_data_processed.volume_fields
+        )
 
 
 class TestDoMINOZarrTransformation:
@@ -115,25 +166,25 @@ class TestDoMINOZarrTransformation:
         assert transform.compressor.cname == "zstd"
         assert transform.compressor.clevel == 5
 
-    def test_transform(self, sample_data):
+    def test_transform(self, sample_data_processed):
         """Test Zarr transformation of DoMINO data."""
         config = ProcessingConfig(
             num_processes=1,
         )
         transform = DoMINOZarrTransformation(config)
 
-        result = transform.transform(sample_data)
+        result = transform.transform(sample_data_processed)
 
         # Check overall structure
         assert isinstance(result, DoMINOZarrDataInMemory)
 
         # Check metadata
-        assert result.metadata == sample_data.metadata
+        assert result.metadata == sample_data_processed.metadata
 
         # Check one STL field
         assert isinstance(result.stl_coordinates, PreparedZarrArrayInfo)
         np.testing.assert_array_equal(
-            result.stl_coordinates.data, sample_data.stl_coordinates
+            result.stl_coordinates.data, sample_data_processed.stl_coordinates
         )
         assert result.stl_coordinates.chunks == (2, 3)
         assert result.stl_coordinates.compressor == transform.compressor
@@ -141,7 +192,7 @@ class TestDoMINOZarrTransformation:
         # Check one surface field
         assert isinstance(result.surface_mesh_centers, PreparedZarrArrayInfo)
         np.testing.assert_array_equal(
-            result.surface_mesh_centers.data, sample_data.surface_mesh_centers
+            result.surface_mesh_centers.data, sample_data_processed.surface_mesh_centers
         )
         assert result.surface_mesh_centers.chunks == (1, 3)
         assert result.surface_mesh_centers.compressor == transform.compressor
@@ -149,7 +200,7 @@ class TestDoMINOZarrTransformation:
         # Check one volume field
         assert isinstance(result.volume_mesh_centers, PreparedZarrArrayInfo)
         np.testing.assert_array_equal(
-            result.volume_mesh_centers.data, sample_data.volume_mesh_centers
+            result.volume_mesh_centers.data, sample_data_processed.volume_mesh_centers
         )
         assert result.volume_mesh_centers.chunks == (1, 3)
         assert result.volume_mesh_centers.compressor == transform.compressor
@@ -206,21 +257,21 @@ class TestDoMINOZarrTransformation:
             else:
                 assert len(w) == 0
 
-    def test_chunk_size_effect(self, sample_data):
+    def test_chunk_size_effect(self, sample_data_processed):
         """Test that different chunk sizes result in different chunking."""
         # Create larger test data for meaningful chunk size testing
         large_data = DoMINOExtractedDataInMemory(
-            metadata=sample_data.metadata,
+            metadata=sample_data_processed.metadata,
             stl_coordinates=np.random.rand(100000, 3),  # Roughly 2.4 MB
-            stl_centers=sample_data.stl_centers,
-            stl_faces=sample_data.stl_faces,
-            stl_areas=sample_data.stl_areas,
-            surface_mesh_centers=sample_data.surface_mesh_centers,
-            surface_normals=sample_data.surface_normals,
-            surface_areas=sample_data.surface_areas,
+            stl_centers=sample_data_processed.stl_centers,
+            stl_faces=sample_data_processed.stl_faces,
+            stl_areas=sample_data_processed.stl_areas,
+            surface_mesh_centers=sample_data_processed.surface_mesh_centers,
+            surface_normals=sample_data_processed.surface_normals,
+            surface_areas=sample_data_processed.surface_areas,
             surface_fields=np.random.rand(100000, 3),  # Roughly 2.4 MB
-            volume_mesh_centers=sample_data.volume_mesh_centers,
-            volume_fields=sample_data.volume_fields,
+            volume_mesh_centers=sample_data_processed.volume_mesh_centers,
+            volume_fields=sample_data_processed.volume_fields,
         )
 
         config = ProcessingConfig(num_processes=1)
@@ -254,3 +305,193 @@ class TestDoMINOZarrTransformation:
         # 1 chunk; (2.4 MB array size / 10.0 MB chunk size)
         large_data_num_chunks = np.ceil(100000 / large_data_elements_per_chunk)
         assert large_data_num_chunks == 1
+
+
+class TestDoMINOPreprocessingTransformation:
+    """Test the DoMINOPreprocessingTransformation class."""
+
+    def test_initialization(self):
+        """Test initialization of preprocessing transformation."""
+        config = ProcessingConfig(num_processes=1)
+        transform = DoMINOPreprocessingTransformation(
+            config,
+            surface_variables={
+                "pMeanTrim": "scalar",
+                "wallShearStressMeanTrim": "vector",
+            },
+            volume_variables={
+                "UMeanTrim": "vector",
+                "pMeanTrim": "scalar",
+            },
+        )
+        assert transform.config == config
+        assert transform.surface_variables == {
+            "pMeanTrim": "scalar",
+            "wallShearStressMeanTrim": "vector",
+        }
+        assert transform.volume_variables == {
+            "UMeanTrim": "vector",
+            "pMeanTrim": "scalar",
+        }
+        assert transform.decimation_algo is None
+        assert transform.target_reduction is None
+
+    def test_initialization_with_decimation(self):
+        """Test initialization with decimation parameters."""
+        config = ProcessingConfig(num_processes=1)
+        transform = DoMINOPreprocessingTransformation(
+            config,
+            surface_variables={"pMeanTrim": "scalar"},
+            volume_variables={"UMeanTrim": "vector"},
+            decimation={"algo": "decimate_pro", "reduction": 0.5},
+        )
+        assert transform.decimation_algo == "decimate_pro"
+        assert transform.target_reduction == 0.5
+
+    def test_initialization_invalid_decimation_algo(self):
+        """Test initialization with invalid decimation algorithm."""
+        config = ProcessingConfig(num_processes=1)
+        with pytest.raises(ValueError, match="Unsupported decimation algo"):
+            DoMINOPreprocessingTransformation(
+                config,
+                decimation={"algo": "invalid_algo", "reduction": 0.5},
+            )
+
+    def test_initialization_invalid_reduction(self):
+        """Test initialization with invalid reduction value."""
+        config = ProcessingConfig(num_processes=1)
+        with pytest.raises(ValueError, match="Expected value in \\[0, 1\\)"):
+            DoMINOPreprocessingTransformation(
+                config,
+                decimation={"algo": "decimate_pro", "reduction": 1.5},
+            )
+
+    def test_transform_basic(self, sample_data_raw):
+        """Test basic preprocessing transformation of DoMINO data."""
+        config = ProcessingConfig(num_processes=1)
+        transform = DoMINOPreprocessingTransformation(
+            config,
+            surface_variables={
+                "pMeanTrim": "scalar",
+                "wallShearStressMeanTrim": "vector",
+            },
+            volume_variables={
+                "UMeanTrim": "vector",
+                "pMeanTrim": "scalar",
+            },
+        )
+
+        result = transform.transform(sample_data_raw)
+        assert isinstance(result, DoMINOExtractedDataInMemory)
+
+        # Check that raw data is cleaned up
+        assert result.stl_polydata is None
+        assert result.surface_polydata is None
+        assert result.volume_unstructured_grid is None
+
+        # Check that processed data is updated and converted to float32
+        assert result.stl_coordinates.dtype == np.float32
+        assert result.stl_centers.dtype == np.float32
+        assert result.stl_faces.dtype == np.float32
+        assert result.stl_areas.dtype == np.float32
+
+        # Check metadata updates
+        assert result.metadata.stream_velocity == 30.0  # From PhysicsConstants
+        assert result.metadata.air_density == 1.205  # From PhysicsConstants
+        assert result.metadata.num_points == 3  # From the test mesh
+        assert result.metadata.num_faces == 3  # From the test mesh
+
+    def test_transform_with_surface_data(self, sample_data_raw):
+        """Test preprocessing transformation with surface data."""
+        config = ProcessingConfig(num_processes=1)
+        transform = DoMINOPreprocessingTransformation(
+            config,
+            surface_variables={
+                "pMeanTrim": "scalar",
+                "wallShearStressMeanTrim": "vector",
+            },
+            volume_variables={
+                "UMeanTrim": "vector",
+                "pMeanTrim": "scalar",
+            },
+        )
+
+        # Set volume data to None since this is a surface data transformation only test.
+        sample_data_raw.volume_unstructured_grid = None
+        result = transform.transform(sample_data_raw)
+
+        # Check surface data processing
+        assert result.surface_mesh_centers.dtype == np.float32
+        assert result.surface_normals.dtype == np.float32
+        assert result.surface_areas.dtype == np.float32
+        assert result.surface_fields.dtype == np.float32
+
+        # Check that surface fields are non-dimensionalized
+        # The normalization factor should be (air_density * stream_velocity^2)
+        normalization_factor = 1.205 * 30.0**2
+        np.testing.assert_array_almost_equal(
+            result.surface_fields,
+            np.array(
+                [[1.0 / normalization_factor, 1.0 / normalization_factor, 0.0, 0.0]]
+            ),
+        )
+
+        # Check that normals are normalized
+        norms = np.linalg.norm(result.surface_normals, axis=1)
+        np.testing.assert_array_almost_equal(norms, np.ones_like(norms))
+
+    def test_transform_with_volume_data(self, sample_data_raw):
+        """Test preprocessing transformation with volume data."""
+        config = ProcessingConfig(num_processes=1)
+        transform = DoMINOPreprocessingTransformation(
+            config,
+            volume_variables={
+                "UMeanTrim": "vector",
+                "pMeanTrim": "scalar",
+            },
+        )
+
+        # Set surface data to None since this is a volume data transformation only test.
+        sample_data_raw.surface_polydata = None
+        result = transform.transform(sample_data_raw)
+
+        # Check volume data processing
+        assert result.volume_mesh_centers.dtype == np.float32
+        assert result.volume_fields.dtype == np.float32
+        assert result.volume_fields is not None
+
+    def test_transform_no_surface_data(self, sample_data_raw):
+        """Test preprocessing transformation without surface data."""
+        config = ProcessingConfig(num_processes=1)
+        transform = DoMINOPreprocessingTransformation(
+            config,
+            volume_variables={"UMeanTrim": "vector"},
+        )
+
+        # Set surface data to None.
+        sample_data_raw.surface_polydata = None
+
+        result = transform.transform(sample_data_raw)
+
+        # Check that surface data is None
+        assert result.surface_mesh_centers is None
+        assert result.surface_normals is None
+        assert result.surface_areas is None
+        assert result.surface_fields is None
+
+    def test_transform_no_volume_data(self, sample_data_raw):
+        """Test preprocessing transformation without volume data."""
+        config = ProcessingConfig(num_processes=1)
+        transform = DoMINOPreprocessingTransformation(
+            config,
+            surface_variables={"pMeanTrim": "scalar"},
+        )
+
+        # Set volume data to None.
+        sample_data_raw.volume_unstructured_grid = None
+
+        result = transform.transform(sample_data_raw)
+
+        # Check that volume data is None
+        assert result.volume_mesh_centers is None
+        assert result.volume_fields is None

--- a/tests/test_examples/test_external_aerodynamics/test_domino/utils.py
+++ b/tests/test_examples/test_external_aerodynamics/test_domino/utils.py
@@ -1,0 +1,101 @@
+import vtk
+
+
+def create_mock_stl(path):
+    """Create a simple STL file."""
+    points = vtk.vtkPoints()
+    points.InsertNextPoint(0, 0, 0)
+    points.InsertNextPoint(1, 0, 0)
+    points.InsertNextPoint(0, 1, 0)
+
+    triangle = vtk.vtkTriangle()
+    triangle.GetPointIds().SetId(0, 0)
+    triangle.GetPointIds().SetId(1, 1)
+    triangle.GetPointIds().SetId(2, 2)
+
+    triangles = vtk.vtkCellArray()
+    triangles.InsertNextCell(triangle)
+
+    polydata = vtk.vtkPolyData()
+    polydata.SetPoints(points)
+    polydata.SetPolys(triangles)
+
+    writer = vtk.vtkSTLWriter()
+    writer.SetFileName(str(path))
+    writer.SetInputData(polydata)
+    writer.Write()
+
+
+def create_mock_surface_vtk(path):
+    """Create a simple surface VTK file."""
+    polydata = vtk.vtkPolyData()
+
+    # Points
+    points = vtk.vtkPoints()
+    points.InsertNextPoint(0, 0, 0)
+    points.InsertNextPoint(1, 0, 0)
+    points.InsertNextPoint(0, 1, 0)
+    polydata.SetPoints(points)
+
+    # Create a cell (triangle)
+    triangle = vtk.vtkTriangle()
+    triangle.GetPointIds().SetId(0, 0)
+    triangle.GetPointIds().SetId(1, 1)
+    triangle.GetPointIds().SetId(2, 2)
+
+    triangles = vtk.vtkCellArray()
+    triangles.InsertNextCell(triangle)
+    polydata.SetPolys(triangles)
+
+    # Surface data - add to CellData instead of PointData
+    pressure = vtk.vtkFloatArray()
+    pressure.SetName("pMeanTrim")
+    pressure.SetNumberOfComponents(1)
+    pressure.InsertNextValue(1.0)  # One value per cell
+
+    shear = vtk.vtkFloatArray()
+    shear.SetName("wallShearStressMeanTrim")
+    shear.SetNumberOfComponents(3)
+    shear.InsertNextTuple3(1, 0, 0)  # One vector per cell
+
+    polydata.GetCellData().AddArray(pressure)  # Changed from PointData to CellData
+    polydata.GetCellData().AddArray(shear)  # Changed from PointData to CellData
+
+    writer = vtk.vtkXMLPolyDataWriter()
+    writer.SetFileName(str(path))
+    writer.SetInputData(polydata)
+    writer.Write()
+
+
+def create_mock_volume_vtk(path):
+    """Create a simple volume VTK file."""
+    grid = vtk.vtkUnstructuredGrid()
+
+    # Points
+    points = vtk.vtkPoints()
+    points.InsertNextPoint(0, 0, 0)
+    points.InsertNextPoint(1, 0, 0)
+    points.InsertNextPoint(0, 1, 0)
+    points.InsertNextPoint(0, 0, 1)
+    grid.SetPoints(points)
+
+    # Volume data
+    velocity = vtk.vtkFloatArray()
+    velocity.SetName("UMeanTrim")
+    velocity.SetNumberOfComponents(3)
+    for _ in range(4):
+        velocity.InsertNextTuple3(1, 0, 0)
+
+    pressure = vtk.vtkFloatArray()
+    pressure.SetName("pMeanTrim")
+    pressure.SetNumberOfComponents(1)
+    for i in range(4):
+        pressure.InsertNextValue(float(i))
+
+    grid.GetPointData().AddArray(velocity)
+    grid.GetPointData().AddArray(pressure)
+
+    writer = vtk.vtkXMLUnstructuredGridWriter()
+    writer.SetFileName(str(path))
+    writer.SetInputData(grid)
+    writer.Write()

--- a/tests/test_examples/test_external_aerodynamics/test_domino/utils.py
+++ b/tests/test_examples/test_external_aerodynamics/test_domino/utils.py
@@ -1,3 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utility functions for DoMINO tests."""
+
 import vtk
 
 


### PR DESCRIPTION
1. DoMINO model can be trained for many use-cases, not just external aerodynamics
2. The current ETL pipeline had transformations which were tightly coupled to the external aero usecase
3. This coupling was due to the fact that the transformations were in the data sources
4. This PR splits these up. Now, the sources only read the data, while the transformations are in a separate class
5. This PR also enables a sequence of transformations, which will get executed one after another, linearly