### PR TITLE
Switch between Zarr and NumPy with one CLI flag

### DIFF
--- a/examples/config/domino_etl.yaml
+++ b/examples/config/domino_etl.yaml
@@ -16,6 +16,8 @@
 
 defaults:
   - /variables: drivaerml
+  - /serialization_format: zarr  # Default value, can be overridden via CLI
+  - /override_transformations: ${serialization_format}
   - _self_
 
 etl:
@@ -55,23 +57,7 @@ etl:
         reduction: 0.0  # 0 means no decimation.
         preserve_topology: false
 
-    # Default - Zarr transformation.
-    # This takes in the processed data and metadata, and converts it into a Zarr/NumPy write ready format.
-    # Users can choose between DoMINOZarrTransformation or DoMINONumpyTransformation.
-    # NOTE: This should match the Sink class' serialization method.
-    # If you choose the NumPy transformation, please comment out the Zarr transformation, and uncomment the below NumPy transformation.
-
-    # TODO (@saikrishnanc): Use Hydra facilities to avoid having to edit the config in multiple places.
-    zarr:
-      _target_: examples.external_aerodynamics.domino.data_transformations.DoMINOZarrTransformation
-      _convert_: all
-      compression_method: "zstd"
-      compression_level: 5
-      chunk_size_mb: 1.0
-
-    # numpy:
-    #   _target_: examples.external_aerodynamics.domino.data_transformations.DoMINONumpyTransformation
-    #   _convert_: all
+    write_ready_transformation: ${override_transformations.write_ready_transformation}
 
   sink:
     _target_: examples.external_aerodynamics.domino.data_sources.DoMINODataSource
@@ -79,6 +65,5 @@ etl:
 
     output_dir: ???  # Path to output directory (required)
     kind: ${etl.common.kind}
-    # "zarr" or "numpy". NOTE: This should match the Transformation class' output format.
-    serialization_method: "zarr"
+    serialization_method: ${serialization_format.serialization_method}
     overwrite_existing: true

--- a/examples/config/override_transformations/numpy.yaml
+++ b/examples/config/override_transformations/numpy.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+write_ready_transformation:
+  _target_: examples.external_aerodynamics.domino.data_transformations.DoMINONumpyTransformation
+  _convert_: all

--- a/examples/config/override_transformations/zarr.yaml
+++ b/examples/config/override_transformations/zarr.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+write_ready_transformation:
+  _target_: examples.external_aerodynamics.domino.data_transformations.DoMINOZarrTransformation
+  _convert_: all
+  compression_method: "zstd"
+  compression_level: 5
+  chunk_size_mb: 1.0

--- a/examples/config/serialization_format/numpy.yaml
+++ b/examples/config/serialization_format/numpy.yaml
@@ -1,0 +1,1 @@
+serialization_method: numpy

--- a/examples/config/serialization_format/zarr.yaml
+++ b/examples/config/serialization_format/zarr.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+serialization_method: zarr

--- a/examples/external_aerodynamics/domino/DoMINO_Data_Processing_Reference.md
+++ b/examples/external_aerodynamics/domino/DoMINO_Data_Processing_Reference.md
@@ -50,10 +50,10 @@ The processed data is stored in either numpy or zarr format:
 
 ```bash
 output/
-└── run_1.npy
+└── run_1.npz
 ```
 
-The `npy` file contains a dictionary with the following keys:
+The `npz` file contains a dictionary with the following keys:
 
 - `stl_coordinates`: (float32) Vertex coordinates from STL geometry
 - `stl_centers`: (float32) Cell center coordinates from STL

--- a/examples/external_aerodynamics/domino/README.md
+++ b/examples/external_aerodynamics/domino/README.md
@@ -20,7 +20,7 @@ The DoMINO ETL pipeline processes automotive aerodynamics simulation data for ma
 - Computes derived quantities and reference values
 - Applies mesh decimation for efficiency (optional)
 
-**Outputs:** Training-ready datasets in numpy or Zarr format
+**Outputs:** Training-ready datasets in NumPy or Zarr format
 
 - Optimized for DoMINO model training workflows
 - Compressed and chunked for efficient data loading
@@ -107,9 +107,7 @@ physicsnemo-curator-etl                    \
 - `etl.common.model_type`: can be `surface` (default) or `volume` or `combined`.
     This option is used to specify the type of model that will be trained on the
     dataset.
-- **Output format**: To switch from Zarr (default) to NumPy, make two changes for consistency:
-  1. In `etl.transformations`: uncomment the `numpy` section and comment out the `zarr` section
-  2. In `etl.sink`: set `serialization_method` to `"numpy"`
+- **Output format**: To switch from Zarr (default) to NumPy, please use the `serialization_format=numpy` flag.
 
 Please refer to the [config file](../../../examples/config/domino_etl.yaml) for more
 options.

--- a/tests/test_examples/test_config.py
+++ b/tests/test_examples/test_config.py
@@ -102,7 +102,7 @@ def test_domino_etl_config():
             "__init__",
             return_value=None,
         ) as m:
-            instantiate(cfg.etl.transformations.zarr)
+            instantiate(cfg.etl.transformations.write_ready_transformation)
             assert m.call_count == 1
 
         # Test sink settings


### PR DESCRIPTION
Previously, to switch between Zarr and NumPy, users had to make changes to 2 parts of the config: one for the final transformation, and another for the sink.
Additionally, the final transformation had to be changed in code. This was cumbersome.

This PR improves this by using Hydra's interpolation feature, and setting defaults which will be loaded accordingly based on the CLI parameter: serialization_format. If that flag is set to be either Zarr or NumPy, the final transformation will also be changed accordingly.