### PR TITLE
Add ability to shuffle volume data

### DIFF
--- a/examples/config/external_aero_etl_drivaerml.yaml
+++ b/examples/config/external_aero_etl_drivaerml.yaml
@@ -95,6 +95,8 @@ etl:
           _partial_: true
         - _target_: examples.external_aerodynamics.external_aero_volume_data_processors.update_volume_data_to_float32
           _partial_: true
+        - _target_: examples.external_aerodynamics.external_aero_volume_data_processors.shuffle_volume_data
+          _partial_: true
 
     write_ready_transformation: ${override_transformations.write_ready_transformation}
 

--- a/examples/external_aerodynamics/external_aero_volume_data_processors.py
+++ b/examples/external_aerodynamics/external_aero_volume_data_processors.py
@@ -64,3 +64,22 @@ def update_volume_data_to_float32(
     data.volume_mesh_centers = to_float32(data.volume_mesh_centers)
     data.volume_fields = to_float32(data.volume_fields)
     return data
+
+
+def shuffle_volume_data(
+    data: ExternalAerodynamicsExtractedDataInMemory,
+    seed: int = 42,
+) -> ExternalAerodynamicsExtractedDataInMemory:
+    """
+    Shuffle volume data.
+
+    This is useful because instead of randomly accessing the data upon read,
+    we can shuffle the data during preprocessing, and do sequential reads.
+    """
+
+    rng = np.random.default_rng(seed)
+    indices = rng.permutation(len(data.volume_mesh_centers))
+    data.volume_mesh_centers = data.volume_mesh_centers[indices]
+    data.volume_fields = data.volume_fields[indices]
+
+    return data


### PR DESCRIPTION
- Volume data is large, and is expensive to do random reads while training
- A proposed solution is to shuffle the data while preprocessing, and do sequential reads while training
- This PR adds a new processor to do this