### PR TITLE
Fix metadata bug in external aero pipeline

### DIFF
--- a/examples/external_aerodynamics/external_aero_surface_data_processors.py
+++ b/examples/external_aerodynamics/external_aero_surface_data_processors.py
@@ -169,6 +169,10 @@ def non_dimensionalize_surface_fields(
     # Non-dimensionalize surface fields
     data.surface_fields = data.surface_fields / (air_density * stream_velocity**2.0)
 
+    # Update metadata
+    data.metadata.air_density = air_density
+    data.metadata.stream_velocity = stream_velocity
+
     return data
 
 

--- a/examples/external_aerodynamics/external_aero_volume_data_processors.py
+++ b/examples/external_aerodynamics/external_aero_volume_data_processors.py
@@ -130,6 +130,15 @@ def non_dimensionalize_volume_fields(
 ) -> ExternalAerodynamicsExtractedDataInMemory:
     """Non-dimensionalize volume fields."""
 
+    if data.volume_fields.shape[0] == 0:
+        logger.error(f"Volume fields are empty: {data.volume_fields}")
+        return data
+
+    if air_density <= 0:
+        logger.error(f"Air density must be > 0: {air_density}")
+    if stream_velocity <= 0:
+        logger.error(f"Stream velocity must be > 0: {stream_velocity}")
+
     stl_vertices = data.stl_polydata.points
     length_scale = np.amax(np.amax(stl_vertices, 0) - np.amin(stl_vertices, 0))
     data.volume_fields[:, :3] = data.volume_fields[:, :3] / stream_velocity
@@ -139,6 +148,11 @@ def non_dimensionalize_volume_fields(
     data.volume_fields[:, 4:] = data.volume_fields[:, 4:] / (
         stream_velocity * length_scale
     )
+
+    # Update metadata
+    data.metadata.air_density = air_density
+    data.metadata.stream_velocity = stream_velocity
+
     return data
 
 

--- a/tests/test_examples/test_external_aerodynamics/test_data_transformations.py
+++ b/tests/test_examples/test_external_aerodynamics/test_data_transformations.py
@@ -687,8 +687,8 @@ class TestExternalAerodynamicsSurfaceTransformation:
             surface_processors=(
                 partial(
                     non_dimensionalize_surface_fields,
-                    air_density=sample_data_raw.metadata.air_density,
-                    stream_velocity=sample_data_raw.metadata.stream_velocity,
+                    air_density=1.00,
+                    stream_velocity=10.00,
                 ),
             ),
         )
@@ -697,12 +697,13 @@ class TestExternalAerodynamicsSurfaceTransformation:
         # Check that the fields were non-dimensionalized
         assert result.surface_fields.shape == sample_data_raw.surface_fields.shape
         # Verify non-dimensionalization: result = original / (rho * V^2)
-        dynamic_pressure_factor = (
-            sample_data_raw.metadata.air_density
-            * sample_data_raw.metadata.stream_velocity**2
-        )
+        dynamic_pressure_factor = 1.00 * 10.00**2  # air_density  # stream_velocity
         expected = np.array([[1.0, 0.5, 0.2, 101325.0]]) / dynamic_pressure_factor
         np.testing.assert_allclose(result.surface_fields, expected, rtol=1e-5)
+
+        # Verify that the metadata was updated
+        assert result.metadata.air_density == 1.00
+        assert result.metadata.stream_velocity == 10.00
 
     def test_transform_with_default_processor_and_filter_invalid_surface_cells(
         self, sample_data_raw
@@ -968,8 +969,8 @@ class TestExternalAerodynamicsVolumeTransformation:
             volume_processors=(
                 partial(
                     non_dimensionalize_volume_fields,
-                    air_density=sample_data_raw.metadata.air_density,
-                    stream_velocity=sample_data_raw.metadata.stream_velocity,
+                    air_density=1.00,
+                    stream_velocity=10.00,
                 ),
             ),
         )
@@ -981,14 +982,17 @@ class TestExternalAerodynamicsVolumeTransformation:
         # Pressure (column 3): divided by (rho * V^2)
         expected_velocity = (
             np.array([[30, 0, 0], [25, 0, 0], [28, 1, 0], [27, 0, 1]])
-            / sample_data_raw.metadata.stream_velocity
+            / 10.00  # stream_velocity
         )
         expected_pressure = np.array([[101325], [101300], [101320], [101310]]) / (
-            sample_data_raw.metadata.air_density
-            * sample_data_raw.metadata.stream_velocity**2
+            1.00 * 10.00**2  # air_density  # stream_velocity
         )
         expected = np.concatenate([expected_velocity, expected_pressure], axis=-1)
         np.testing.assert_allclose(result.volume_fields, expected, rtol=1e-5)
+
+        # Verify that the metadata was updated
+        assert result.metadata.air_density == 1.00
+        assert result.metadata.stream_velocity == 10.00
 
     def test_transform_with_default_processor_and_shuffle_data(self, sample_data_raw):
         """Test volume transformation with shuffle on top of the default processor."""


### PR DESCRIPTION
- For non dimensionalization surface/volume processors, the right air density/stream_velocities were being applied for the transformations, but the metadata was NOT being updated to reflect this
- This PR fixes this