### PR TITLE
Update drivaer MLexample to  add boundary conditions to outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Slurm jobs:
+*.err
+*.out
+
 *pycache*
 *outputs*
 *egg-info*

--- a/docs/domains/mesh.md
+++ b/docs/domains/mesh.md
@@ -46,7 +46,7 @@ from physicsnemo_curator.domains.mesh.sources.drivaerml import DrivAerMLSource
 source = DrivAerMLSource(mesh_type="boundary")
 ```
 
-**Supported formats:** `.vtk`, `.vtp`, `.vtu`, `.vts`, `.vtm`
+**Supported formats:** `.vtk`, `.vtp`, `.vtu`, `.vts`, `.vtm`, `.stl`
 
 **Constructor parameters:**
 
@@ -54,9 +54,63 @@ source = DrivAerMLSource(mesh_type="boundary")
 |-----------|------|---------|-------------|
 | `input_path` | `str` | *required* | Path to local directory containing VTK files |
 | `file_pattern` | `str` | `"**"` | Glob pattern for filtering files |
-| `manifold_dim` | `int \| "auto"` | `"auto"` | Target manifold dimension (0–3) |
-| `point_source` | `str` | `"vertices"` | `"vertices"` or `"cell_centroids"` |
+| `manifold_dim` | `int \| "auto" \| list[dict]` | `"auto"` | Target manifold dimension (0–3), or per-path rule list |
+| `point_source` | `str \| list[dict]` | `"vertices"` | `"vertices"` or `"cell_centroids"` (or per-path rule list) |
 | `warn_on_lost_data` | `bool` | `True` | Warn when data arrays are discarded |
+| `backend` | `str` | `"pyvista"` | Reading backend: `"pyvista"` or `"rust"` (faster VTU/VTP) |
+| `key_filters` | `list[dict] \| None` | `None` | Per-path data-array include/exclude rules (reader-level) |
+| `volume_pattern` | `str \| None` | `None` | Filename glob for volume files (domain-mesh mode) |
+| `boundary_pattern` | `str \| None` | `None` | Filename glob for boundary files (domain-mesh mode) |
+| `boundary_name` | `str` | `"vehicle"` | Boundary key for the paired DomainMesh boundary |
+| `boundary_generator` | object \| `None` | `None` | Optional BC generator applied to each paired DomainMesh |
+
+**Reading backends:**
+
+- `"pyvista"` (default): full-featured reading via `from_pyvista`.
+- `"rust"`: native reader for `.vtu` / `.vtp` (much faster I/O), with a
+  transparent fallback to PyVista for unsupported files/configs. Builds the
+  `Mesh` (points, cells, point/cell data, or cell centroids) directly from
+  raw arrays.
+
+**Per-path conversion and array filtering:**
+
+`manifold_dim` and `point_source` accept either a scalar (applied to every
+file) or a list of `{"pattern": glob, "value": ...}` rules selected per file
+(longest matching pattern wins). `key_filters` drops/keeps named data arrays
+**at the reader level** (so filtered fields are never materialised — critical
+for very large volume `.vtu` files):
+
+```python
+source = VTKSource(
+    "./dataset/",
+    backend="rust",
+    manifold_dim=[
+        {"pattern": "**/volume_*", "value": 0},     # volumes -> point cloud
+        {"pattern": "**/boundary_*", "value": 2},   # surfaces -> triangulated
+    ],
+    point_source=[{"pattern": "**/volume_*", "value": "cell_centroids"}],
+    key_filters=[
+        {"path_pattern": "**/volume_*.vtu", "mode": "exclude", "keys": ["NodeID"]},
+    ],
+)
+```
+
+**Domain-mesh mode (volume + boundary -> DomainMesh):**
+
+When both `volume_pattern` and `boundary_pattern` are set, files are paired
+**by parent directory** into a {class}`physicsnemo.mesh.domain_mesh.DomainMesh`
+per index (one volume interior + one boundary). Unpaired files (e.g. STLs)
+fall back to standalone `Mesh`:
+
+```python
+source = VTKSource(
+    "./dataset/",
+    volume_pattern="volume_*.vtu",
+    boundary_pattern="boundary_*.vtp",
+    boundary_name="vehicle",
+)
+domain = next(source[0])  # DomainMesh(interior=..., boundaries={"vehicle": ...})
+```
 
 **Manifold dimensions:**
 
@@ -164,6 +218,12 @@ memory-mapped format ({meth}`Mesh.save`).
 |-----------|------|---------|-------------|
 | `output_dir` | `str` | *required* | Directory for output files |
 | `naming_template` | `str \| None` | `None` | Format string for output names (see below) |
+| `group_readable` | `bool` | `False` | `chmod g+r` the written output |
+
+Writes are **atomic**: each mesh is written to a temporary directory in the
+same parent and then renamed into place, so an interrupted run never leaves a
+partial/corrupt output directory behind. `Mesh` objects are saved as `.pmsh`
+and `DomainMesh` objects as `.pdmsh`.
 
 **Output naming:** By default each mesh is saved to
 `{output_dir}/mesh_{index:04d}_{seq}` where `index` is the source item
@@ -206,6 +266,93 @@ sink = MeshSink(
     naming_template="boundary_{index}.vtp.pmsh",
 )
 paths = pipeline[0]  # ['./output/boundary_0.vtp.pmsh']
+```
+
+### Transform filters
+
+Several generic, in-pipeline transform filters complement the statistics
+filters above. All are importable from
+`physicsnemo_curator.domains.mesh.filters` and apply to both `Mesh` and
+`DomainMesh` (interior + every boundary).
+
+| Filter | Purpose |
+|--------|---------|
+| `PrecisionFilter` | Convert field precision (e.g. fp64 → fp32 / fp16 / bf16) |
+| `CleanFilter` | `Mesh.clean`: merge duplicate points, drop duplicate cells / unused points |
+| `PointDataToCellDataFilter` | Move `point_data` onto cells by per-cell averaging |
+| `GlobalDataFilter` | Inject constant `global_data` (e.g. `U_inf`, `rho_inf`, …) |
+| `RandomPermutationFilter` | Shuffle point/cell ordering reproducibly |
+| `FieldSelectFilter` | Keep/drop fields after conversion (post-hoc) |
+| `BoundaryInjectionFilter` | Synthesize + inject CFD-domain boundaries (see below) |
+
+```python
+from physicsnemo_curator.domains.mesh.filters import (
+    CleanFilter, GlobalDataFilter, PointDataToCellDataFilter,
+)
+
+pipeline = (
+    source
+    .filter(CleanFilter())
+    .filter(PointDataToCellDataFilter())  # surface point_data -> cell_data
+    .filter(GlobalDataFilter(values={"U_inf": [30.0, 0.0, 0.0], "rho_inf": 1.225}))
+    .write(sink)
+)
+```
+
+### VTISource and GridSidecarSink (structured grids)
+
+VTK ImageData (`.vti`) describes a uniform rectilinear grid (origin + spacing
++ dimensions) and does not fit the unstructured `Mesh` model.
+{class}`~physicsnemo_curator.domains.mesh.sources.vti.VTISource` reads each
+`.vti` file into a {class}`tensordict.TensorDict` of **dense N-D field
+tensors** instead:
+
+- `point_data` — sub-TensorDict with `batch_size = [Nz, Ny, Nx]`; scalar
+  fields are `(Nz, Ny, Nx)`, vector fields `(Nz, Ny, Nx, C)` (VTK x-fastest
+  ordering).
+- `cell_data` — sub-TensorDict with `batch_size = [Cz, Cy, Cx]`.
+- `grid` — non-batched metadata: `origin`, `spacing`, `dimensions`,
+  `direction`.
+
+{class}`~physicsnemo_curator.domains.mesh.sinks.grid_sidecar.GridSidecarSink`
+writes the grid as a tensordict memmap **sidecar** beside the mesh outputs
+(default `{relpath}/{stem}.grid`), reloadable with
+`TensorDict.load_memmap`:
+
+```python
+from physicsnemo_curator.domains.mesh.sources.vti import VTISource
+from physicsnemo_curator.domains.mesh.sinks.grid_sidecar import GridSidecarSink
+
+pipeline = VTISource("./grids/").write(GridSidecarSink(output_dir="./out/"))
+```
+
+### Boundary-condition injection
+
+Curated `DomainMesh` files often carry only the geometry surface (`vehicle`)
+plus interior + global data, lacking the CFD-domain outer boundaries
+(inlet / outlet / walls / symmetry). The
+`physicsnemo_curator.domains.mesh.boundaries` subsystem synthesizes those
+boundaries from the known domain geometry and injects them, preserving
+`interior` / `vehicle` / `global_data`.
+
+Datasets are specialized purely by choosing a `BoundaryGenerator` and its
+constants:
+
+- `BoxTunnelBoundaries` — rectangular wind tunnel (inlet/outlet/slip/no_slip);
+  `z_floor` inferred per sample from the geometry boundary.
+- `HemisphereBoundaries` — hemispherical open-road domain (inlet/outlet split
+  by freestream direction + a constrained-Delaunay symmetry disk).
+
+Use it either as a standalone filter on any `DomainMesh` stream (including
+reading existing `.pdmsh`), or as the `boundary_generator` hook on
+`VTKSource` domain-mesh mode:
+
+```python
+from physicsnemo_curator.domains.mesh.boundaries import HemisphereBoundaries
+from physicsnemo_curator.domains.mesh.filters import BoundaryInjectionFilter
+
+gen = HemisphereBoundaries(freestream_key="U_inf")
+pipeline = source.filter(BoundaryInjectionFilter(gen, check_watertight=True)).write(sink)
 ```
 
 ## Dependencies

--- a/docs/domains/mesh.md
+++ b/docs/domains/mesh.md
@@ -301,8 +301,8 @@ pipeline = (
 
 ### VTISource and GridSidecarSink (structured grids)
 
-VTK ImageData (`.vti`) describes a uniform rectilinear grid (origin + spacing
-+ dimensions) and does not fit the unstructured `Mesh` model.
+VTK ImageData (`.vti`) describes a uniform rectilinear grid (origin + spacing +
+dimensions) and does not fit the unstructured `Mesh` model.
 {class}`~physicsnemo_curator.domains.mesh.sources.vti.VTISource` reads each
 `.vti` file into a {class}`tensordict.TensorDict` of **dense N-D field
 tensors** instead:

--- a/examples/cae/drivaerml/README.md
+++ b/examples/cae/drivaerml/README.md
@@ -7,15 +7,20 @@ automotive CFD meshes through a complete Source → Filter → Sink pipeline.
 
 The pipeline:
 
-1. **MeshStatsFilter** — computes per-field statistics (mean, std,
-   skewness, kurtosis) using Welford accumulators that merge across
-   parallel workers.
-2. **PrecisionFilter** — casts float64 fields to float32.
-3. **RandomPermutationFilter** — shuffles point and cell ordering to
+1. **BoundaryInjectionFilter** — synthesizes the rectangular wind-tunnel
+   boundaries (`inlet`, `outlet`, `slip`, `no_slip`) the dataset ships
+   without and injects them into each `DomainMesh` alongside the existing
+   `vehicle` surface (via `BoxTunnelBoundaries`, inferring the floor height
+   per sample). STL meshes pass through unchanged.
+2. **RandomPermutationFilter** — shuffles point and cell ordering to
    remove spatial bias before training.
-4. **MeshSink** — writes each mesh in PhysicsNeMo's native format
+3. **MeshSink** — writes each mesh in PhysicsNeMo's native format
    (`.pdmsh` for DomainMesh, `.pmsh` for plain Mesh), grouped into
    per-run subdirectories.
+
+`DrivAerMLSource` already downcasts to float32, so a separate
+`PrecisionFilter` is not needed. Pass `--check-watertight` to log
+`DomainMesh.check_boundary_watertight` after injection.
 
 ## Prerequisites
 
@@ -83,7 +88,17 @@ python main.py --input /path/to/drivaerml --output /path/to/output
 
 # Limit to specific number of workers
 python main.py --workers 4
+
+# Process only the first N runs (handy for a quick test)
+python main.py --limit 2
+
+# Verify the synthesized boundary surface is watertight (informational)
+python main.py --check-watertight
 ```
+
+Each output `domain_{run}.pdmsh` carries the interior, the `vehicle`
+surface, and the injected `inlet` / `outlet` / `slip` / `no_slip`
+boundaries.
 
 ## Output Structure
 

--- a/examples/cae/drivaerml/main.py
+++ b/examples/cae/drivaerml/main.py
@@ -19,10 +19,20 @@
 import argparse
 from pathlib import Path
 
+from physicsnemo_curator.domains.mesh.boundaries import BoxTunnelBoundaries
+from physicsnemo_curator.domains.mesh.filters.boundary_injection import BoundaryInjectionFilter
 from physicsnemo_curator.domains.mesh.filters.random_permutation import RandomPermutationFilter
 from physicsnemo_curator.domains.mesh.sinks.mesh_writer import MeshSink
 from physicsnemo_curator.domains.mesh.sources.drivaerml import DrivAerMLSource
 from physicsnemo_curator.run import run_pipeline
+
+# DrivAerML rectangular wind-tunnel domain (arXiv:2408.11969 v2, Sect. C / Fig. 11).
+# All in metres in the DrivAerML coordinate system; z_floor is inferred per
+# sample from the vehicle surface (tire contact patch).
+_X_MIN, _X_MAX = -40.0, 80.0
+_Y_MIN, _Y_MAX = -22.0, 22.0
+_Z_HEIGHT = 20.0
+_X_BL = -2.339  # slip-to-noslip floor transition
 
 
 def main() -> None:
@@ -45,6 +55,23 @@ def main() -> None:
         type=int,
         default=1,
         help="Number of parallel workers (default: 1)",
+    )
+    parser.add_argument(
+        "--check-watertight",
+        action="store_true",
+        help="Verify (and log) DomainMesh.is_boundary_watertight after injecting boundaries",
+    )
+    parser.add_argument(
+        "--start",
+        type=int,
+        default=0,
+        help="Index of the first run to process (0-based offset, for chunking across jobs)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Process at most N runs starting at --start (default: all remaining)",
     )
     args = parser.parse_args()
 
@@ -69,20 +96,51 @@ def main() -> None:
     print(f"Input: {input_dir}")
     print(f"Output: {output_dir}")
 
+    # Synthesize the rectangular wind-tunnel boundaries (inlet/outlet/slip/
+    # no_slip) the dataset ships without, inferring the floor height per
+    # sample from the vehicle surface.
+    boundary_generator = BoxTunnelBoundaries(
+        x_min=_X_MIN,
+        x_max=_X_MAX,
+        y_min=_Y_MIN,
+        y_max=_Y_MAX,
+        z_height=_Z_HEIGHT,
+        x_bl=_X_BL,
+        vehicle_key="vehicle",
+    )
+
     # Build the pipeline:
-    # 1. RandomPermutationFilter — shuffle point/cell order
-    # 2. MeshSink — write to per-run subdirectories
+    # 1. BoundaryInjectionFilter — add inlet/outlet/slip/no_slip to each
+    #    DomainMesh (STL meshes pass through unchanged).
+    # 2. RandomPermutationFilter — shuffle point/cell order.
+    # 3. MeshSink — write to per-run subdirectories.
     # Note: PrecisionFilter is not needed since DrivAerMLSource already
     # downcasts to float32 internally.
-    pipeline = source.filter(RandomPermutationFilter(seed=42)).write(
-        MeshSink(
-            output_dir=str(output_dir),
-            naming_template="run_{run_id}/{mesh_name}",
+    pipeline = (
+        source.filter(BoundaryInjectionFilter(boundary_generator, check_watertight=args.check_watertight))
+        .filter(RandomPermutationFilter(seed=42))
+        .write(
+            MeshSink(
+                output_dir=str(output_dir),
+                naming_template="run_{run_id}/{mesh_name}",
+            )
         )
     )
 
-    # Run the pipeline
-    results = run_pipeline(pipeline, n_jobs=args.workers, backend="process_pool")
+    # Select a contiguous chunk of runs [start, start + limit) for this job.
+    start = max(0, args.start)
+    stop = n_runs if args.limit is None else min(start + args.limit, n_runs)
+    indices: range | None
+    if start > 0 or args.limit is not None:
+        indices = range(start, stop)
+        print(f"Processing runs [{start}, {stop}) -> {len(indices)} run(s)")
+    else:
+        indices = None
+
+    # Run the pipeline. With a single worker use the sequential backend so a
+    # node only ever holds one (large) volume mesh in memory at a time.
+    backend = "process_pool" if args.workers > 1 else "sequential"
+    results = run_pipeline(pipeline, n_jobs=args.workers, backend=backend, indices=indices)
 
     print(f"\nProcessed {len(results)} runs")
     for i, paths in enumerate(results):

--- a/examples/cae/vti_grids/main.py
+++ b/examples/cae/vti_grids/main.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Convert VTK ImageData (``.vti``) structured grids to tensordict memmaps.
+
+Reads ``.vti`` files into dense N-D field tensors (via
+:class:`~physicsnemo_curator.domains.mesh.sources.vti.VTISource`) and writes
+each as a tensordict memmap ``.grid`` directory (via
+:class:`~physicsnemo_curator.domains.mesh.sinks.grid_sidecar.GridSidecarSink`),
+mirroring the input directory layout under ``--output``.
+
+Each output preserves the structured-grid layout:
+
+* ``point_data`` — sub-TensorDict, ``batch_size = [Nz, Ny, Nx]``
+* ``cell_data``  — sub-TensorDict, ``batch_size = [Cz, Cy, Cx]``
+* ``grid``       — ``origin``, ``spacing``, ``dimensions``, ``direction``
+
+Reload an output with ``tensordict.TensorDict.load_memmap(path)``.
+
+Sidecar usage
+-------------
+To drop each grid **next to** the corresponding mesh outputs
+(``.pmsh`` / ``.pdmsh``) for the same samples, point ``--output`` at the
+**same output root** your mesh conversion writes to and keep the default
+``{relpath}/{stem}`` naming.  Each grid then lands in the same per-sample
+directory as that sample's mesh.
+
+Examples
+--------
+::
+
+    # Quick test on the first 2 files
+    python main.py --input /data/grids --output output/grids --limit 2
+
+    # Full run, 8 workers, group-readable output
+    python main.py --input /data/grids --output output/grids --workers 8 --group-readable
+
+    # Co-locate grids beside existing mesh outputs (sidecar)
+    python main.py --input /data/grids --output output/drivaerml
+"""
+
+import argparse
+from pathlib import Path
+
+from physicsnemo_curator.domains.mesh.sinks.grid_sidecar import GridSidecarSink
+from physicsnemo_curator.domains.mesh.sources.vti import VTISource
+from physicsnemo_curator.run import run_pipeline
+
+
+def main() -> None:
+    """Run the VTI -> tensordict-memmap conversion pipeline."""
+    parser = argparse.ArgumentParser(description="Convert .vti structured grids to tensordict memmaps")
+    parser.add_argument(
+        "--input",
+        type=Path,
+        default=Path("input/vti"),
+        help="Path to a .vti file or a directory of .vti files (default: input/vti)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("output/vti"),
+        help="Output root for .grid sidecars (default: output/vti)",
+    )
+    parser.add_argument(
+        "--pattern",
+        type=str,
+        default="**/*",
+        help="Glob pattern for discovering files under --input (default: **/*)",
+    )
+    parser.add_argument(
+        "--naming-template",
+        type=str,
+        default="{relpath}/{stem}",
+        help="Output name template; placeholders {index}, {seq}, {relpath}, {stem} (default: {relpath}/{stem})",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Process only the first N files (default: all)",
+    )
+    parser.add_argument(
+        "--workers",
+        type=int,
+        default=1,
+        help="Number of parallel workers (default: 1). Each worker holds a full grid in RAM.",
+    )
+    parser.add_argument(
+        "--fp32",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Downcast float64 arrays to float32 (default: True; use --no-fp32 to keep native)",
+    )
+    parser.add_argument(
+        "--group-readable",
+        action="store_true",
+        help="Make written outputs group-readable (chmod g+r)",
+    )
+    args = parser.parse_args()
+
+    input_path: Path = args.input.resolve()
+    output_dir: Path = args.output.resolve()
+
+    source = VTISource(str(input_path), file_pattern=args.pattern, fp32=args.fp32)
+
+    n_files = len(source)
+    print(f"Discovered {n_files} .vti file(s)")
+    print(f"Input:  {input_path}")
+    print(f"Output: {output_dir}")
+    if n_files:
+        rel = Path(source.relative_path(0))
+        example_out = output_dir / rel.parent / f"{rel.stem}.grid"
+        print(f"Example: {rel} -> {example_out}")
+
+    pipeline = source.write(
+        GridSidecarSink(
+            output_dir=str(output_dir),
+            naming_template=args.naming_template,
+            group_readable=args.group_readable,
+        )
+    )
+
+    indices = range(min(args.limit, n_files)) if args.limit is not None else None
+    if indices is not None:
+        print(f"Limiting to first {len(indices)} file(s)")
+
+    backend = "process_pool" if args.workers > 1 else "sequential"
+    results = run_pipeline(pipeline, n_jobs=args.workers, backend=backend, indices=indices)
+
+    print(f"\nConverted {len(results)} file(s)")
+    for paths in results:
+        for p in paths:
+            print(f"  {p}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/physicsnemo_curator/dashboard/views/performance.py
+++ b/src/physicsnemo_curator/dashboard/views/performance.py
@@ -28,7 +28,7 @@ import panel_material_ui as pmui
 if TYPE_CHECKING:
     from physicsnemo_curator.dashboard.data import DashboardStore
 
-hv.extension("bokeh")  # ty: ignore[too-many-positional-arguments]
+hv.extension("bokeh")
 
 
 def _timeline_scatter(store: DashboardStore) -> pn.Column:

--- a/src/physicsnemo_curator/domains/atm/filters/stats.py
+++ b/src/physicsnemo_curator/domains/atm/filters/stats.py
@@ -491,7 +491,7 @@ class AtomicStatsFilter(Filter["AtomicData"]):
         import panel_material_ui as pmui
         from bokeh.models import HoverTool
 
-        hv.extension("bokeh")  # ty: ignore[too-many-positional-arguments]
+        hv.extension("bokeh")
         stat_columns: list[str] = [
             "index",
             "mean",

--- a/src/physicsnemo_curator/domains/da/filters/stats.py
+++ b/src/physicsnemo_curator/domains/da/filters/stats.py
@@ -359,7 +359,7 @@ class DataArrayStatsFilter(Filter["xr.DataArray"]):
         import holoviews as hv
         import panel as pn
 
-        hv.extension("bokeh")  # ty: ignore[too-many-positional-arguments]
+        hv.extension("bokeh")
 
         if not artifact_paths:
             return pn.pane.Markdown("*No DataArray Statistics artifacts found.*")

--- a/src/physicsnemo_curator/domains/mesh/boundaries/__init__.py
+++ b/src/physicsnemo_curator/domains/mesh/boundaries/__init__.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generic boundary-condition synthesis and injection for DomainMesh objects."""
+
+from physicsnemo_curator.domains.mesh.boundaries.generators import (
+    BoundaryGenerator,
+    BoxTunnelBoundaries,
+    HemisphereBoundaries,
+)
+from physicsnemo_curator.domains.mesh.boundaries.inject import inject_boundaries
+
+__all__ = [
+    "BoundaryGenerator",
+    "BoxTunnelBoundaries",
+    "HemisphereBoundaries",
+    "inject_boundaries",
+]

--- a/src/physicsnemo_curator/domains/mesh/boundaries/_geometry.py
+++ b/src/physicsnemo_curator/domains/mesh/boundaries/_geometry.py
@@ -584,9 +584,7 @@ def constrained_delaunay_disk(
             keep_mask &= ~point_in_polygon(cell_centroids_xz, sil)
         out_cells = out_cells[keep_mask]
 
-    out_points = torch.from_numpy(
-        np.column_stack([all_xz[:, 0], np.zeros(len(all_xz)), all_xz[:, 1]])
-    ).float()
+    out_points = torch.from_numpy(np.column_stack([all_xz[:, 0], np.zeros(len(all_xz)), all_xz[:, 1]])).float()
 
     # Re-orient each cell to +y (inward); vtkDelaunay2D winding is not
     # guaranteed consistent under our axis swap.

--- a/src/physicsnemo_curator/domains/mesh/boundaries/_geometry.py
+++ b/src/physicsnemo_curator/domains/mesh/boundaries/_geometry.py
@@ -1,0 +1,603 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Dataset-agnostic boundary-synthesis geometry toolkit.
+
+These helpers synthesize CFD-domain outer boundaries (inlet / outlet / walls /
+symmetry planes) for :class:`~physicsnemo.mesh.domain_mesh.DomainMesh` samples
+that ship with only a geometry surface (``vehicle``).  They are the reusable
+primitives behind the :mod:`...boundaries.generators` strategies and cover the
+two common archetypes:
+
+* **box wind tunnel** — axis-aligned box-face patches with inward normals
+  (:func:`box_face_patch`, :func:`box_tunnel_boundaries`).
+* **hemispherical open-road domain** — a triangulated hemisphere split into
+  inlet/outlet by freestream direction (:func:`build_hemisphere`,
+  :func:`split_by_freestream`) plus a constrained-Delaunay symmetry disk with
+  the vehicle silhouette as holes (:func:`silhouette_loops`,
+  :func:`constrained_delaunay_disk`).
+
+All synthesized boundaries use inward-pointing cell normals (into the fluid).
+"""
+
+from __future__ import annotations
+
+import logging
+import warnings
+from typing import Literal
+
+import numpy as np
+import torch
+from physicsnemo.mesh import Mesh
+from physicsnemo.mesh.primitives.planar import structured_grid
+from physicsnemo.mesh.projections import embed
+
+logger = logging.getLogger(__name__)
+
+#: ``((x_min, x_max), (y_min, y_max), (z_min, z_max))`` axis-aligned bounds.
+Bounds3D = tuple[tuple[float, float], tuple[float, float], tuple[float, float]]
+
+#: Box face label.
+Face = Literal["x_min", "x_max", "y_min", "y_max", "z_min", "z_max"]
+
+
+# ---------------------------------------------------------------------------
+# Per-sample geometry inference
+# ---------------------------------------------------------------------------
+
+
+def z_floor_from_boundary(mesh: Mesh) -> float:
+    """Infer the ground-plane height from a boundary mesh's minimum z.
+
+    Parameters
+    ----------
+    mesh : Mesh
+        Boundary mesh (e.g. the vehicle surface).
+
+    Returns
+    -------
+    float
+        The minimum z-coordinate (tire / contact-patch height).
+    """
+    return float(mesh.points[:, 2].min())
+
+
+def radius_from_interior(interior: Mesh) -> float:
+    """Infer a hemisphere radius from the interior point-cloud bounding box.
+
+    Parameters
+    ----------
+    interior : Mesh
+        Interior point cloud (roughly fills the hemisphere).
+
+    Returns
+    -------
+    float
+        The max of ``|x|``, ``y``, ``|z|`` over the interior points.
+    """
+    p = interior.points
+    return max(float(p[:, 0].abs().max()), float(p[:, 1].max()), float(p[:, 2].abs().max()))
+
+
+# ---------------------------------------------------------------------------
+# Box wind-tunnel boundaries
+# ---------------------------------------------------------------------------
+
+
+def box_face_patch(
+    *,
+    bounds: Bounds3D,
+    face: Face,
+    n_per_side: tuple[int, int] = (20, 20),
+) -> Mesh:
+    """Build one triangulated rectangular face of an axis-aligned box.
+
+    Cell winding is chosen so that normals point inward (into the box
+    interior).
+
+    Parameters
+    ----------
+    bounds : Bounds3D
+        ``((x_min, x_max), (y_min, y_max), (z_min, z_max))`` of the box.
+    face : Face
+        Which face to construct (e.g. ``"z_min"`` is the floor).
+    n_per_side : tuple[int, int]
+        Grid resolution along the two in-plane axes (in xyz order).
+
+    Returns
+    -------
+    Mesh
+        A ``Mesh[2, 3]`` surface patch with inward normals.
+    """
+    axis_name, side = face.split("_")
+    axis_idx = "xyz".index(axis_name)
+    constant_value = bounds[axis_idx][0 if side == "min" else 1]
+
+    # Inward normal: at the min face the fluid lies at higher coordinate, so
+    # inward is +axis; at the max face inward is -axis.
+    inward_sign = +1 if side == "min" else -1
+
+    in_plane_axes = [i for i in range(3) if i != axis_idx]
+    a_idx, b_idx = in_plane_axes
+    a_min, a_max = bounds[a_idx]
+    b_min, b_max = bounds[b_idx]
+    n_a, n_b = n_per_side
+
+    grid_2d = structured_grid.load(x_min=a_min, x_max=a_max, y_min=b_min, y_max=b_max, n_x=n_a, n_y=n_b)
+    embedded = embed(grid_2d, target_n_spatial_dims=3, insert_at=axis_idx)
+    offset = [0.0, 0.0, 0.0]
+    offset[axis_idx] = constant_value
+    embedded = embedded.translate(offset)
+
+    # Probe the first cell's natural normal and flip winding if it does not
+    # already match the inward direction on the constant axis.
+    p0 = embedded.points[embedded.cells[0, 0]]
+    p1 = embedded.points[embedded.cells[0, 1]]
+    p2 = embedded.points[embedded.cells[0, 2]]
+    natural_normal = torch.linalg.cross(p1 - p0, p2 - p0)
+    natural_sign = float(torch.sign(natural_normal[axis_idx]))
+
+    cells = embedded.cells
+    if natural_sign * inward_sign < 0.0:
+        cells = cells[:, [0, 2, 1]]
+
+    return Mesh(points=embedded.points, cells=cells)
+
+
+def box_tunnel_boundaries(
+    *,
+    bounds: Bounds3D,
+    x_bl: float,
+    n_per_side: tuple[int, int] = (20, 20),
+) -> dict[str, Mesh]:
+    """Build rectangular wind-tunnel boundaries: inlet/outlet/slip/no_slip.
+
+    ``slip`` merges the two sidewalls, the ceiling, and the forward floor
+    (upstream of *x_bl*); ``no_slip`` is the rear floor.  All normals point
+    inward.
+
+    Parameters
+    ----------
+    bounds : Bounds3D
+        CFD-domain bounds; ``z_min`` is the floor, ``z_max`` the ceiling.
+    x_bl : float
+        Streamwise coordinate where the floor transitions from slip
+        (upstream) to no-slip (downstream).
+    n_per_side : tuple[int, int]
+        Per-face triangulation resolution.
+
+    Returns
+    -------
+    dict[str, Mesh]
+        ``{"inlet", "outlet", "slip", "no_slip"}``.
+
+    Raises
+    ------
+    ValueError
+        If *x_bl* lies outside the streamwise extent.
+    """
+    if not (bounds[0][0] <= x_bl <= bounds[0][1]):
+        msg = f"x_bl={x_bl!r} must lie inside x range {bounds[0]!r}."
+        raise ValueError(msg)
+
+    inlet = box_face_patch(bounds=bounds, face="x_min", n_per_side=n_per_side)
+    outlet = box_face_patch(bounds=bounds, face="x_max", n_per_side=n_per_side)
+    ceiling = box_face_patch(bounds=bounds, face="z_max", n_per_side=n_per_side)
+    side_y_min = box_face_patch(bounds=bounds, face="y_min", n_per_side=n_per_side)
+    side_y_max = box_face_patch(bounds=bounds, face="y_max", n_per_side=n_per_side)
+
+    floor_slip_bounds: Bounds3D = ((bounds[0][0], x_bl), bounds[1], bounds[2])
+    floor_noslip_bounds: Bounds3D = ((x_bl, bounds[0][1]), bounds[1], bounds[2])
+    floor_slip = box_face_patch(bounds=floor_slip_bounds, face="z_min", n_per_side=n_per_side)
+    no_slip = box_face_patch(bounds=floor_noslip_bounds, face="z_min", n_per_side=n_per_side)
+
+    slip = Mesh.merge([floor_slip, ceiling, side_y_min, side_y_max])
+
+    return {"inlet": inlet, "outlet": outlet, "slip": slip, "no_slip": no_slip}
+
+
+# ---------------------------------------------------------------------------
+# Hemisphere open-road boundaries
+# ---------------------------------------------------------------------------
+
+
+def build_hemisphere(
+    radius: float,
+    *,
+    n_theta: int = 64,
+    n_phi: int = 32,
+) -> tuple[Mesh, torch.Tensor]:
+    """Build a triangulated hemisphere ``y >= 0`` with the equator at ``y = 0``.
+
+    Cell winding is chosen so normals point inward (toward the origin).
+
+    Parameters
+    ----------
+    radius : float
+        Hemisphere radius.
+    n_theta : int
+        Azimuthal divisions around the y-axis (``>= 3``).
+    n_phi : int
+        Polar divisions from north pole to equator (``>= 2``).
+
+    Returns
+    -------
+    tuple[Mesh, torch.Tensor]
+        ``(mesh, equator_indices)`` — the hemisphere ``Mesh[2, 3]`` and the
+        ``(n_theta,)`` point indices on the equator (the last ring), whose
+        coordinates the symmetry disk reuses for a watertight seam.
+
+    Raises
+    ------
+    ValueError
+        If *n_theta* < 3 or *n_phi* < 2.
+    """
+    if n_theta < 3:
+        msg = f"need n_theta >= 3, got {n_theta=}"
+        raise ValueError(msg)
+    if n_phi < 2:
+        msg = f"need n_phi >= 2, got {n_phi=}"
+        raise ValueError(msg)
+
+    phi = torch.linspace(0.0, torch.pi / 2, n_phi)
+    theta = torch.linspace(0.0, 2.0 * torch.pi, n_theta + 1)[:-1]
+
+    pole = torch.tensor([[0.0, radius, 0.0]])
+    rings: list[torch.Tensor] = []
+    for r in range(n_phi - 1):
+        p = phi[r + 1].item()
+        ring_y = 0.0 if r == n_phi - 2 else radius * np.cos(p)
+        ring_xz_radius = radius * np.sin(p)
+        rx = ring_xz_radius * torch.cos(theta)
+        rz = ring_xz_radius * torch.sin(theta)
+        rings.append(torch.stack([rx, torch.full_like(rx, ring_y), rz], dim=-1))
+
+    points = torch.cat([pole, *rings], dim=0).float()
+
+    cell_rows: list[list[int]] = []
+    for i in range(n_theta):
+        i_next = (i + 1) % n_theta
+        cell_rows.append([0, 1 + i, 1 + i_next])
+    for r in range(n_phi - 2):
+        ring_r = 1 + r * n_theta
+        ring_r1 = 1 + (r + 1) * n_theta
+        for i in range(n_theta):
+            i_next = (i + 1) % n_theta
+            v00 = ring_r + i
+            v01 = ring_r + i_next
+            v10 = ring_r1 + i
+            v11 = ring_r1 + i_next
+            cell_rows.append([v00, v10, v01])
+            cell_rows.append([v01, v10, v11])
+
+    cells = torch.tensor(cell_rows, dtype=torch.int64)
+
+    # Verify (and enforce) inward winding across every cell.
+    p0_all = points[cells[:, 0]]
+    p1_all = points[cells[:, 1]]
+    p2_all = points[cells[:, 2]]
+    centroids_all = (p0_all + p1_all + p2_all) / 3.0
+    normals_all = torch.linalg.cross(p1_all - p0_all, p2_all - p0_all)
+    dots = (centroids_all * normals_all).sum(dim=-1)
+    if bool((dots > 0).all()):
+        cells = cells[:, [0, 2, 1]]
+        dots = -dots
+    if not bool((dots < 0).all().item()):
+        n_outward = int((dots > 0).sum().item())
+        msg = f"hemisphere triangulation has mixed winding: {n_outward}/{cells.shape[0]} cells point outward."
+        raise RuntimeError(msg)
+
+    mesh = Mesh(points=points, cells=cells)
+    equator_indices = torch.arange(points.shape[0] - n_theta, points.shape[0])
+    return mesh, equator_indices
+
+
+def split_by_freestream(hemisphere: Mesh, u_inf: torch.Tensor) -> tuple[Mesh, Mesh]:
+    """Split a hemisphere into inlet (upstream) and outlet (downstream).
+
+    Each cell is classified by the sign of ``dot(centroid, U_inf)``:
+    ``<= 0`` -> inlet, ``> 0`` -> outlet.
+
+    Parameters
+    ----------
+    hemisphere : Mesh
+        Hemisphere mesh from :func:`build_hemisphere`.
+    u_inf : torch.Tensor
+        ``(3,)`` freestream velocity vector (direction only).
+
+    Returns
+    -------
+    tuple[Mesh, Mesh]
+        ``(inlet, outlet)`` meshes sharing exact seam vertex coordinates.
+
+    Raises
+    ------
+    ValueError
+        If *u_inf* is not shape ``(3,)``.
+    """
+    if tuple(u_inf.shape) != (3,):
+        msg = f"u_inf must be shape (3,), got {tuple(u_inf.shape)}"
+        raise ValueError(msg)
+
+    centroids = hemisphere.cell_centroids
+    direction = u_inf / u_inf.norm()
+    dots = centroids @ direction.to(centroids.dtype)
+
+    inlet_idx = (dots <= 0).nonzero(as_tuple=True)[0]
+    outlet_idx = (dots > 0).nonzero(as_tuple=True)[0]
+
+    inlet = hemisphere.slice_cells(inlet_idx).clean(
+        merge_points=False, remove_duplicate_cells=False, remove_unused_points=True
+    )
+    outlet = hemisphere.slice_cells(outlet_idx).clean(
+        merge_points=False, remove_duplicate_cells=False, remove_unused_points=True
+    )
+    return inlet, outlet
+
+
+# ---------------------------------------------------------------------------
+# Vehicle silhouette extraction (open edges on a symmetry plane)
+# ---------------------------------------------------------------------------
+
+
+def silhouette_loops(vehicle: Mesh, *, y_eps: float = 1e-3) -> list[torch.Tensor]:
+    """Extract closed loops of vehicle vertex indices on the ``y = 0`` plane.
+
+    An "open" edge (shared by exactly one triangle) whose endpoints both lie
+    on the symmetry plane traces the silhouette of a half-geometry mesh.
+
+    Parameters
+    ----------
+    vehicle : Mesh
+        Half-geometry surface mesh (points with ``y >= 0``).
+    y_eps : float
+        Tolerance for "vertex lies on the symmetry plane".
+
+    Returns
+    -------
+    list[torch.Tensor]
+        One 1-D tensor of vertex indices per closed loop (loop order, no
+        repeated start).  Empty if there are no open edges on the plane.
+    """
+    cells = vehicle.cells
+    on_plane = vehicle.points[:, 1].abs() < y_eps
+
+    cell_on_plane = on_plane[cells]
+    n_on_plane_per_cell = cell_on_plane.sum(dim=1)
+
+    relevant = n_on_plane_per_cell >= 2
+    rel_cells = cells[relevant]
+    rel_on_plane = cell_on_plane[relevant]
+
+    edge_pairs = torch.tensor([[0, 1], [1, 2], [2, 0]], dtype=torch.int64)
+    edge_endpoints = rel_cells[:, edge_pairs]
+    edge_both_on = rel_on_plane[:, edge_pairs].all(dim=-1)
+
+    candidate_edges = edge_endpoints[edge_both_on]
+    if candidate_edges.numel() == 0:
+        return []
+
+    candidate_edges_sorted = candidate_edges.sort(dim=-1).values
+    unique_edges, inverse = torch.unique(candidate_edges_sorted, dim=0, return_inverse=True)
+    counts = torch.bincount(inverse)
+    boundary_edges = unique_edges[counts == 1]
+
+    if boundary_edges.shape[0] == 0:
+        return []
+
+    return walk_closed_loops(boundary_edges)
+
+
+def walk_closed_loops(edges: torch.Tensor) -> list[torch.Tensor]:
+    """Group an undirected edge set into closed loops via half-edge traversal.
+
+    Parameters
+    ----------
+    edges : torch.Tensor
+        ``(K, 2)`` vertex index pairs.
+
+    Returns
+    -------
+    list[torch.Tensor]
+        One 1-D long tensor per closed loop (arbitrary start, no repeated end).
+    """
+    edges_np = edges.cpu().numpy()
+
+    adjacency: dict[int, list[int]] = {}
+    for a, b in edges_np:
+        adjacency.setdefault(int(a), []).append(int(b))
+        adjacency.setdefault(int(b), []).append(int(a))
+
+    bad_degree = {v: len(ns) for v, ns in adjacency.items() if len(ns) != 2}
+    if bad_degree:
+        warnings.warn(
+            f"silhouette: {len(bad_degree)} vertices with non-2 degree "
+            f"(sample: {dict(list(bad_degree.items())[:5])}); loop extraction may be incomplete.",
+            stacklevel=2,
+        )
+
+    visited: set[int] = set()
+    loops: list[list[int]] = []
+    for start in adjacency:
+        if start in visited or len(adjacency[start]) != 2:
+            continue
+        loop = [start]
+        visited.add(start)
+        prev = -1
+        current = start
+        while True:
+            options = [n for n in adjacency[current] if n != prev]
+            if not options:
+                break
+            next_v = options[0]
+            if next_v == start:
+                break
+            loop.append(next_v)
+            visited.add(next_v)
+            prev = current
+            current = next_v
+        if len(loop) >= 3:
+            loops.append(loop)
+
+    return [torch.tensor(loop, dtype=torch.int64) for loop in loops]
+
+
+# ---------------------------------------------------------------------------
+# 2D geometry helpers
+# ---------------------------------------------------------------------------
+
+
+def polygon_area(loop_xz: torch.Tensor) -> float:
+    """Return the absolute area of a closed 2D polygon (shoelace formula).
+
+    Parameters
+    ----------
+    loop_xz : torch.Tensor
+        ``(n, 2)`` vertex coordinates.
+
+    Returns
+    -------
+    float
+        Absolute polygon area.
+    """
+    x = loop_xz[:, 0]
+    z = loop_xz[:, 1]
+    return float(0.5 * torch.abs((x * z.roll(-1) - x.roll(-1) * z).sum()))
+
+
+def point_in_polygon(points_xz: torch.Tensor, polygon_xz: torch.Tensor) -> torch.Tensor:
+    """Vectorised point-in-polygon test via horizontal ray casting.
+
+    Parameters
+    ----------
+    points_xz : torch.Tensor
+        ``(N, 2)`` query points.
+    polygon_xz : torch.Tensor
+        ``(M, 2)`` polygon vertices in loop order (implicitly closed).
+
+    Returns
+    -------
+    torch.Tensor
+        ``(N,)`` bool tensor; ``True`` where a point is inside the polygon.
+    """
+    qx = points_xz[:, 0:1]
+    qz = points_xz[:, 1:2]
+    a = polygon_xz
+    b = polygon_xz.roll(-1, dims=0)
+    az = a[:, 1].unsqueeze(0)
+    bz = b[:, 1].unsqueeze(0)
+    ax = a[:, 0].unsqueeze(0)
+    bx = b[:, 0].unsqueeze(0)
+
+    crosses = (az > qz) != (bz > qz)
+    denom = bz - az
+    safe_denom = torch.where(denom != 0.0, denom, torch.ones_like(denom))
+    t = (qz - az) / safe_denom
+    inter_x = ax + t * (bx - ax)
+
+    n_crossings = (crosses & (inter_x > qx)).sum(dim=-1)
+    return (n_crossings % 2) == 1
+
+
+def constrained_delaunay_disk(
+    *,
+    equator_xz: torch.Tensor,
+    silhouette_xzs: list[torch.Tensor],
+) -> Mesh:
+    """Triangulate the symmetry-plane disk with silhouettes as holes.
+
+    Uses ``vtkDelaunay2D`` (via PyVista) with the equator + silhouette loops
+    as edge constraints.  The output sits in the ``y = 0`` plane with ``+y``
+    (inward) normals; output point coordinates are bit-identical to the inputs
+    so they dedupe cleanly against the hemisphere equator and vehicle
+    silhouette.
+
+    Parameters
+    ----------
+    equator_xz : torch.Tensor
+        ``(n_eq, 2)`` ``(x, z)`` of the hemisphere equator vertices.
+    silhouette_xzs : list[torch.Tensor]
+        List of ``(n_i, 2)`` ``(x, z)`` silhouette loops (may be empty).
+
+    Returns
+    -------
+    Mesh
+        Disk ``Mesh[2, 3]`` at ``y = 0`` with inward (``+y``) normals.
+
+    Raises
+    ------
+    ValueError
+        If the equator has fewer than 3 vertices.
+    RuntimeError
+        If the triangulation returns no / non-triangle cells.
+    """
+    import pyvista as pv
+
+    if equator_xz.shape[0] < 3:
+        msg = f"equator must have >=3 vertices, got {equator_xz.shape[0]}"
+        raise ValueError(msg)
+
+    blocks = [equator_xz, *list(silhouette_xzs)]
+    offsets = np.cumsum([0] + [b.shape[0] for b in blocks]).tolist()
+    all_xz = torch.cat(blocks, dim=0).cpu().numpy()
+
+    points_in_xy = np.column_stack([all_xz[:, 0], all_xz[:, 1], np.zeros(len(all_xz))]).astype(np.float64)
+
+    line_records: list[int] = []
+    for lo, hi in zip(offsets[:-1], offsets[1:], strict=True):
+        n = hi - lo
+        for i in range(n):
+            line_records.extend([2, lo + i, lo + (i + 1) % n])
+
+    edge_source = pv.PolyData(points_in_xy, lines=np.asarray(line_records))
+    point_set = pv.PolyData(points_in_xy)
+    triangulated = point_set.delaunay_2d(edge_source=edge_source, alpha=0.0, tol=1e-8)
+
+    faces = np.asarray(triangulated.faces)
+    if faces.size == 0:
+        msg = "vtkDelaunay2D returned zero triangles; check that the equator encloses every silhouette."
+        raise RuntimeError(msg)
+    faces = faces.reshape(-1, 4)
+    if not np.all(faces[:, 0] == 3):
+        msg = f"vtkDelaunay2D returned non-triangle cells (sizes: {np.unique(faces[:, 0])})"
+        raise RuntimeError(msg)
+    out_cells = torch.from_numpy(faces[:, 1:].astype(np.int64))
+
+    # Drop spurious triangles that vtkDelaunay2D places inside silhouette holes.
+    if silhouette_xzs:
+        cell_centroids_xz = torch.from_numpy(all_xz[out_cells.numpy()].mean(axis=1))
+        keep_mask = torch.ones(out_cells.shape[0], dtype=torch.bool)
+        for sil in silhouette_xzs:
+            keep_mask &= ~point_in_polygon(cell_centroids_xz, sil)
+        out_cells = out_cells[keep_mask]
+
+    out_points = torch.from_numpy(
+        np.column_stack([all_xz[:, 0], np.zeros(len(all_xz)), all_xz[:, 1]])
+    ).float()
+
+    # Re-orient each cell to +y (inward); vtkDelaunay2D winding is not
+    # guaranteed consistent under our axis swap.
+    p0_all = out_points[out_cells[:, 0]]
+    p1_all = out_points[out_cells[:, 1]]
+    p2_all = out_points[out_cells[:, 2]]
+    ny_all = torch.linalg.cross(p1_all - p0_all, p2_all - p0_all)[:, 1]
+    flip_mask = ny_all < 0.0
+    if bool(flip_mask.any()):
+        fixed = out_cells.clone()
+        fixed[flip_mask] = out_cells[flip_mask][:, [0, 2, 1]]
+        out_cells = fixed
+
+    return Mesh(points=out_points, cells=out_cells)

--- a/src/physicsnemo_curator/domains/mesh/boundaries/generators.py
+++ b/src/physicsnemo_curator/domains/mesh/boundaries/generators.py
@@ -1,0 +1,188 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pluggable boundary-condition generators.
+
+A :class:`BoundaryGenerator` synthesizes the missing CFD-domain outer
+boundaries for a :class:`~physicsnemo.mesh.domain_mesh.DomainMesh` that ships
+with only a geometry surface.  Datasets are specialized purely by choosing a
+generator and its constants:
+
+* :class:`BoxTunnelBoundaries` — rectangular wind tunnel (DrivAerML, ShiftSUV).
+* :class:`HemisphereBoundaries` — hemispherical open-road domain with a
+  symmetry plane (HighLiftAeroML).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+from physicsnemo_curator.domains.mesh.boundaries import _geometry as geom
+
+if TYPE_CHECKING:
+    from physicsnemo.mesh import Mesh
+    from physicsnemo.mesh.domain_mesh import DomainMesh
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class BoundaryGenerator(Protocol):
+    """Protocol for boundary-condition generators.
+
+    Implementations synthesize named outer-boundary meshes from a domain's
+    known geometry (interior, the existing geometry surface, and
+    ``global_data``).
+    """
+
+    def generate(self, domain: DomainMesh) -> dict[str, Mesh]:
+        """Return a mapping of new boundary name -> synthesized Mesh.
+
+        Parameters
+        ----------
+        domain : DomainMesh
+            The input domain mesh (interior + existing boundaries + global
+            data).
+
+        Returns
+        -------
+        dict[str, Mesh]
+            New outer boundaries to inject.
+        """
+        ...
+
+
+class BoxTunnelBoundaries:
+    """Generate rectangular wind-tunnel boundaries (inlet/outlet/slip/no_slip).
+
+    The vertical floor height ``z_floor`` is, by default, inferred per sample
+    from the minimum z of the geometry boundary (tire / contact patch); pass
+    *z_floor* to override.
+
+    Parameters
+    ----------
+    x_min, x_max : float
+        Streamwise extents of the CFD domain.
+    y_min, y_max : float
+        Lateral extents.
+    z_height : float
+        Vertical extent above the floor.
+    x_bl : float
+        Streamwise coordinate of the slip-to-noslip floor transition.
+    n_per_side : tuple[int, int]
+        Per-face triangulation resolution.
+    z_floor : float or None
+        Fixed floor height; ``None`` infers from the geometry boundary.
+    vehicle_key : str
+        Boundary key of the geometry surface used for ``z_floor`` inference.
+    """
+
+    def __init__(
+        self,
+        *,
+        x_min: float,
+        x_max: float,
+        y_min: float,
+        y_max: float,
+        z_height: float,
+        x_bl: float,
+        n_per_side: tuple[int, int] = (20, 20),
+        z_floor: float | None = None,
+        vehicle_key: str = "vehicle",
+    ) -> None:
+        self._x_min = x_min
+        self._x_max = x_max
+        self._y_min = y_min
+        self._y_max = y_max
+        self._z_height = z_height
+        self._x_bl = x_bl
+        self._n_per_side = n_per_side
+        self._z_floor = z_floor
+        self._vehicle_key = vehicle_key
+
+    def generate(self, domain: DomainMesh) -> dict[str, Mesh]:
+        """Synthesize inlet/outlet/slip/no_slip boundaries for *domain*."""
+        if self._z_floor is not None:
+            z_floor = self._z_floor
+        else:
+            vehicle = domain.boundaries[self._vehicle_key]
+            z_floor = geom.z_floor_from_boundary(vehicle)
+
+        bounds: geom.Bounds3D = (
+            (self._x_min, self._x_max),
+            (self._y_min, self._y_max),
+            (z_floor, z_floor + self._z_height),
+        )
+        return geom.box_tunnel_boundaries(bounds=bounds, x_bl=self._x_bl, n_per_side=self._n_per_side)
+
+
+class HemisphereBoundaries:
+    """Generate hemispherical open-road boundaries (inlet/outlet/symmetry).
+
+    The hemisphere radius is, by default, inferred per sample from the
+    interior point-cloud bounding box; pass *radius* to override.  The
+    inlet/outlet split is along the great half-circle perpendicular to the
+    freestream direction read from ``global_data[freestream_key]``, so it is
+    sample-dependent (encodes angle of attack).
+
+    Parameters
+    ----------
+    radius : float or None
+        Hemisphere radius; ``None`` infers from the interior bbox.
+    n_theta, n_phi : int
+        Hemisphere triangulation resolution.
+    y_eps : float
+        Tolerance for "vertex on the symmetry plane".
+    freestream_key : str
+        ``global_data`` key holding the freestream velocity vector.
+    vehicle_key : str
+        Boundary key of the geometry surface (provides the silhouette).
+    """
+
+    def __init__(
+        self,
+        *,
+        radius: float | None = None,
+        n_theta: int = 64,
+        n_phi: int = 32,
+        y_eps: float = 1e-3,
+        freestream_key: str = "U_inf",
+        vehicle_key: str = "vehicle",
+    ) -> None:
+        self._radius = radius
+        self._n_theta = n_theta
+        self._n_phi = n_phi
+        self._y_eps = y_eps
+        self._freestream_key = freestream_key
+        self._vehicle_key = vehicle_key
+
+    def generate(self, domain: DomainMesh) -> dict[str, Mesh]:
+        """Synthesize inlet/outlet/symmetry boundaries for *domain*."""
+        radius = self._radius if self._radius is not None else geom.radius_from_interior(domain.interior)
+
+        hemisphere, equator_idx = geom.build_hemisphere(radius, n_theta=self._n_theta, n_phi=self._n_phi)
+
+        u_inf = domain.global_data[self._freestream_key]
+        inlet, outlet = geom.split_by_freestream(hemisphere, u_inf)
+
+        vehicle = domain.boundaries[self._vehicle_key]
+        loops = geom.silhouette_loops(vehicle, y_eps=self._y_eps)
+        silhouette_xzs = [vehicle.points[loop][:, [0, 2]] for loop in loops]
+        equator_xz = hemisphere.points[equator_idx][:, [0, 2]]
+        symmetry = geom.constrained_delaunay_disk(equator_xz=equator_xz, silhouette_xzs=silhouette_xzs)
+
+        return {"inlet": inlet, "outlet": outlet, "symmetry": symmetry}

--- a/src/physicsnemo_curator/domains/mesh/boundaries/inject.py
+++ b/src/physicsnemo_curator/domains/mesh/boundaries/inject.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Boundary-condition injection into a DomainMesh."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from physicsnemo.mesh.domain_mesh import DomainMesh
+
+    from physicsnemo_curator.domains.mesh.boundaries.generators import BoundaryGenerator
+
+logger = logging.getLogger(__name__)
+
+
+def inject_boundaries(domain: DomainMesh, generator: BoundaryGenerator) -> DomainMesh:
+    """Return a new DomainMesh with synthesized boundaries injected.
+
+    The existing ``interior`` and ``global_data`` are preserved, and the
+    generator's synthesized boundaries are merged alongside the existing
+    boundaries (e.g. the geometry ``vehicle`` surface).
+
+    Parameters
+    ----------
+    domain : DomainMesh
+        The input domain mesh.
+    generator : BoundaryGenerator
+        Strategy producing ``{name: Mesh}`` outer boundaries.
+
+    Returns
+    -------
+    DomainMesh
+        New domain mesh with original + synthesized boundaries.
+    """
+    from physicsnemo.mesh.domain_mesh import DomainMesh as _DomainMesh
+
+    new_outer = generator.generate(domain)
+
+    existing = domain.boundaries
+    boundaries: dict[str, object] = {}
+    if existing is not None:
+        for name in existing.keys():  # noqa: SIM118 - TensorDict needs .keys()
+            boundaries[str(name)] = existing[name]
+    boundaries.update(new_outer)
+
+    logger.info(
+        "Injected %d boundary(ies) %s; total boundaries: %s",
+        len(new_outer),
+        sorted(new_outer.keys()),
+        sorted(boundaries.keys()),
+    )
+
+    return _DomainMesh(
+        interior=domain.interior,
+        boundaries=boundaries,
+        global_data=domain.global_data,
+    )

--- a/src/physicsnemo_curator/domains/mesh/filters/__init__.py
+++ b/src/physicsnemo_curator/domains/mesh/filters/__init__.py
@@ -16,21 +16,29 @@
 
 """Mesh data filters/transforms."""
 
+from physicsnemo_curator.domains.mesh.filters.boundary_injection import BoundaryInjectionFilter
+from physicsnemo_curator.domains.mesh.filters.clean import CleanFilter
 from physicsnemo_curator.domains.mesh.filters.edge_compute import EdgeComputeFilter
 from physicsnemo_curator.domains.mesh.filters.field_select import FieldSelectFilter
+from physicsnemo_curator.domains.mesh.filters.global_data import GlobalDataFilter
 from physicsnemo_curator.domains.mesh.filters.mean import MeanFilter
 from physicsnemo_curator.domains.mesh.filters.mesh_info import MeshInfoFilter
+from physicsnemo_curator.domains.mesh.filters.point_data_to_cell import PointDataToCellDataFilter
 from physicsnemo_curator.domains.mesh.filters.precision import PrecisionFilter
 from physicsnemo_curator.domains.mesh.filters.quality import MeshQualityFilter
 from physicsnemo_curator.domains.mesh.filters.random_permutation import RandomPermutationFilter
 from physicsnemo_curator.domains.mesh.filters.wall_node import WallNodeFilter
 
 __all__ = [
+    "BoundaryInjectionFilter",
+    "CleanFilter",
     "EdgeComputeFilter",
     "FieldSelectFilter",
+    "GlobalDataFilter",
     "MeanFilter",
     "MeshInfoFilter",
     "MeshQualityFilter",
+    "PointDataToCellDataFilter",
     "PrecisionFilter",
     "RandomPermutationFilter",
     "WallNodeFilter",

--- a/src/physicsnemo_curator/domains/mesh/filters/boundary_injection.py
+++ b/src/physicsnemo_curator/domains/mesh/filters/boundary_injection.py
@@ -149,10 +149,12 @@ class BoundaryInjectionFilter(Filter["Mesh"]):
             The injected domain mesh to check.
         """
         try:
-            if hasattr(domain, "is_boundary_watertight"):
-                watertight = domain.is_boundary_watertight(tolerance=self._watertight_tolerance)
-            elif hasattr(domain, "check_boundary_watertight"):
-                watertight = domain.check_boundary_watertight()
+            is_boundary_watertight = getattr(domain, "is_boundary_watertight", None)
+            check_boundary_watertight = getattr(domain, "check_boundary_watertight", None)
+            if is_boundary_watertight is not None:
+                watertight = is_boundary_watertight(tolerance=self._watertight_tolerance)
+            elif check_boundary_watertight is not None:
+                watertight = check_boundary_watertight()
             else:
                 logger.warning("BoundaryInjectionFilter: no watertight-check method on DomainMesh.")
                 return

--- a/src/physicsnemo_curator/domains/mesh/filters/boundary_injection.py
+++ b/src/physicsnemo_curator/domains/mesh/filters/boundary_injection.py
@@ -1,0 +1,161 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Boundary-condition injection filter for DomainMesh pipelines.
+
+Applies a :class:`~physicsnemo_curator.domains.mesh.boundaries.BoundaryGenerator`
+to each :class:`~physicsnemo.mesh.domain_mesh.DomainMesh` flowing through,
+synthesizing the missing CFD-domain outer boundaries (inlet / outlet / walls /
+symmetry) and merging them alongside the existing geometry boundary while
+preserving ``interior`` and ``global_data``.
+
+Plain :class:`~physicsnemo.mesh.Mesh` objects (no boundaries) pass through
+unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from physicsnemo_curator.core.base import Filter, Param
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from physicsnemo.mesh import Mesh
+
+logger = logging.getLogger(__name__)
+
+
+class BoundaryInjectionFilter(Filter["Mesh"]):
+    """Inject synthesized outer boundaries into each DomainMesh.
+
+    Parameters
+    ----------
+    generator : BoundaryGenerator
+        Strategy that synthesizes ``{name: Mesh}`` outer boundaries from a
+        domain (e.g.
+        :class:`~physicsnemo_curator.domains.mesh.boundaries.BoxTunnelBoundaries`
+        or
+        :class:`~physicsnemo_curator.domains.mesh.boundaries.HemisphereBoundaries`).
+    check_watertight : bool
+        If ``True``, log :meth:`DomainMesh.is_boundary_watertight` after
+        injection (informational; can be expensive).  Default ``False``.
+    watertight_tolerance : float
+        Tolerance forwarded to ``is_boundary_watertight``.  Default ``1e-3``.
+
+    Examples
+    --------
+    >>> from physicsnemo_curator.domains.mesh.boundaries import HemisphereBoundaries
+    >>> filt = BoundaryInjectionFilter(HemisphereBoundaries())  # doctest: +SKIP
+    >>> pipeline = source.filter(filt).write(sink)  # doctest: +SKIP
+    """
+
+    name: ClassVar[str] = "Boundary Injection"
+    description: ClassVar[str] = "Synthesize and inject CFD-domain outer boundaries into DomainMesh objects"
+
+    @classmethod
+    def params(cls) -> list[Param]:
+        """Return parameter descriptors for the filter.
+
+        Returns
+        -------
+        list[Param]
+            The ``generator``, ``check_watertight``, and
+            ``watertight_tolerance`` parameters.
+        """
+        return [
+            Param(name="generator", description="BoundaryGenerator strategy instance", type=object),
+            Param(
+                name="check_watertight",
+                description="Log is_boundary_watertight after injection",
+                type=bool,
+                default=False,
+            ),
+            Param(
+                name="watertight_tolerance",
+                description="Tolerance for the watertight check",
+                type=float,
+                default=1e-3,
+            ),
+        ]
+
+    def __init__(
+        self,
+        generator: Any,
+        check_watertight: bool = False,
+        watertight_tolerance: float = 1e-3,
+    ) -> None:
+        self._generator = generator
+        self._check_watertight = check_watertight
+        self._watertight_tolerance = watertight_tolerance
+
+    def __call__(self, items: Generator[Mesh]) -> Generator[Mesh]:
+        """Inject boundaries into each DomainMesh in the stream.
+
+        Parameters
+        ----------
+        items : Generator[Mesh]
+            Stream of incoming meshes.  Non-DomainMesh items pass through.
+
+        Yields
+        ------
+        Mesh
+            DomainMesh with synthesized boundaries injected (or the original
+            item when it is not a DomainMesh).
+        """
+        from physicsnemo.mesh.domain_mesh import DomainMesh as _DomainMesh
+
+        from physicsnemo_curator.domains.mesh.boundaries import inject_boundaries
+
+        for mesh in items:
+            if not isinstance(mesh, _DomainMesh):
+                logger.warning("BoundaryInjectionFilter received a non-DomainMesh item; passing through unchanged.")
+                yield mesh
+                continue
+
+            injected = inject_boundaries(mesh, self._generator)
+
+            if self._check_watertight:
+                self._log_watertight(injected)
+
+            yield injected
+
+    def _log_watertight(self, domain: object) -> None:
+        """Log the boundary watertightness, tolerant of physicsnemo API drift.
+
+        Different physicsnemo versions expose either
+        ``is_boundary_watertight(tolerance=...)`` or
+        ``check_boundary_watertight()``.  The check is informational, so any
+        failure is logged rather than raised.
+
+        Parameters
+        ----------
+        domain : DomainMesh
+            The injected domain mesh to check.
+        """
+        try:
+            if hasattr(domain, "is_boundary_watertight"):
+                watertight = domain.is_boundary_watertight(tolerance=self._watertight_tolerance)
+            elif hasattr(domain, "check_boundary_watertight"):
+                watertight = domain.check_boundary_watertight()
+            else:
+                logger.warning("BoundaryInjectionFilter: no watertight-check method on DomainMesh.")
+                return
+            logger.info("BoundaryInjectionFilter: boundary watertight=%s", watertight)
+        except Exception as exc:  # noqa: BLE001 - informational check must not break the pipeline
+            logger.warning("BoundaryInjectionFilter: watertight check failed: %s", exc)

--- a/src/physicsnemo_curator/domains/mesh/filters/clean.py
+++ b/src/physicsnemo_curator/domains/mesh/filters/clean.py
@@ -1,0 +1,186 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Mesh cleaning filter for mesh pipelines.
+
+Wraps :meth:`physicsnemo.mesh.Mesh.clean` to merge duplicate points, remove
+duplicate cells, and drop unused points from meshes imported from external
+sources (VTK, STL, CAD).  A **new** mesh is yielded.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, ClassVar
+
+from physicsnemo_curator.core.base import Filter, Param
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from physicsnemo.mesh import Mesh
+
+logger = logging.getLogger(__name__)
+
+
+class CleanFilter(Filter["Mesh"]):
+    """Clean and repair meshes via :meth:`Mesh.clean`.
+
+    For each incoming mesh the filter optionally merges spatially-duplicate
+    points, removes duplicate cells, and drops points not referenced by any
+    cell.  Meshes without cells (point clouds) are passed through unchanged,
+    since ``remove_unused_points`` would otherwise discard every point.
+
+    For :class:`~physicsnemo.mesh.domain_mesh.DomainMesh` objects the interior
+    and every boundary sub-mesh are cleaned independently.
+
+    Parameters
+    ----------
+    tolerance : float
+        Absolute L2 distance threshold for merging duplicate points.
+        Default ``1e-12``.
+    merge_points : bool
+        Merge spatially-duplicate points (default ``True``).
+    remove_duplicate_cells : bool
+        Remove cells with identical vertex sets (default ``True``).
+    remove_unused_points : bool
+        Drop points not referenced by any cell (default ``True``).
+
+    Examples
+    --------
+    >>> filt = CleanFilter()  # doctest: +SKIP
+    >>> pipeline = source.filter(filt).write(sink)  # doctest: +SKIP
+    """
+
+    name: ClassVar[str] = "Mesh Clean"
+    description: ClassVar[str] = "Merge duplicate points, remove duplicate cells, and drop unused points"
+
+    @classmethod
+    def params(cls) -> list[Param]:
+        """Return parameter descriptors for the clean filter.
+
+        Returns
+        -------
+        list[Param]
+            Cleaning option parameters.
+        """
+        return [
+            Param(name="tolerance", description="L2 distance threshold for merging points", type=float, default=1e-12),
+            Param(name="merge_points", description="Merge spatially-duplicate points", type=bool, default=True),
+            Param(
+                name="remove_duplicate_cells",
+                description="Remove cells with identical vertex sets",
+                type=bool,
+                default=True,
+            ),
+            Param(
+                name="remove_unused_points",
+                description="Drop points not referenced by any cell",
+                type=bool,
+                default=True,
+            ),
+        ]
+
+    def __init__(
+        self,
+        tolerance: float = 1e-12,
+        merge_points: bool = True,
+        remove_duplicate_cells: bool = True,
+        remove_unused_points: bool = True,
+    ) -> None:
+        self._tolerance = tolerance
+        self._merge_points = merge_points
+        self._remove_duplicate_cells = remove_duplicate_cells
+        self._remove_unused_points = remove_unused_points
+
+    def __call__(self, items: Generator[Mesh]) -> Generator[Mesh]:
+        """Clean each mesh in the stream.
+
+        Parameters
+        ----------
+        items : Generator[Mesh]
+            Stream of incoming meshes (Mesh or DomainMesh).
+
+        Yields
+        ------
+        Mesh
+            Cleaned mesh (a new object when cleaning was applied).
+        """
+        from physicsnemo.mesh.domain_mesh import DomainMesh as _DomainMesh
+
+        for mesh in items:
+            if isinstance(mesh, _DomainMesh):
+                yield self._clean_domain_mesh(mesh)
+            else:
+                yield self._clean_mesh(mesh)
+
+    def _clean_mesh(self, mesh: Mesh) -> Mesh:
+        """Clean a single Mesh, skipping point clouds.
+
+        Parameters
+        ----------
+        mesh : Mesh
+            The mesh to clean.
+
+        Returns
+        -------
+        Mesh
+            Cleaned mesh, or the original when it has no cells.
+        """
+        if mesh.cells is None or mesh.n_cells == 0:
+            return mesh
+        n_pts_before, n_cells_before = mesh.n_points, mesh.n_cells
+        cleaned = mesh.clean(
+            tolerance=self._tolerance,
+            merge_points=self._merge_points,
+            remove_duplicate_cells=self._remove_duplicate_cells,
+            remove_unused_points=self._remove_unused_points,
+        )
+        logger.debug(
+            "CleanFilter: points %d->%d, cells %d->%d",
+            n_pts_before,
+            cleaned.n_points,
+            n_cells_before,
+            cleaned.n_cells,
+        )
+        return cleaned
+
+    def _clean_domain_mesh(self, domain_mesh: object) -> object:
+        """Clean interior and boundary sub-meshes of a DomainMesh.
+
+        Parameters
+        ----------
+        domain_mesh : DomainMesh
+            The domain mesh to clean.
+
+        Returns
+        -------
+        DomainMesh
+            A new domain mesh with cleaned sub-meshes.
+        """
+        from physicsnemo.mesh.domain_mesh import DomainMesh as _DomainMesh
+
+        interior = self._clean_mesh(domain_mesh.interior)  # ty: ignore[unresolved-attribute]
+        boundaries = domain_mesh.boundaries  # ty: ignore[unresolved-attribute]
+        new_boundaries = {}
+        if boundaries is not None:
+            for name in boundaries.keys():  # noqa: SIM118 - TensorDict needs .keys()
+                new_boundaries[str(name)] = self._clean_mesh(boundaries[name])
+        return _DomainMesh(
+            interior=interior,
+            boundaries=new_boundaries,
+            global_data=domain_mesh.global_data,  # ty: ignore[unresolved-attribute]
+        )

--- a/src/physicsnemo_curator/domains/mesh/filters/global_data.py
+++ b/src/physicsnemo_curator/domains/mesh/filters/global_data.py
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Global-data injection filter for mesh pipelines.
+
+Injects constant ``global_data`` entries (e.g. freestream conditions such as
+``U_inf``, ``rho_inf``, ``p_inf``, ``nu``, ``L_ref``) into each mesh flowing
+through.  This is the generic, config-driven counterpart to the per-dataset
+constants hardcoded in domain-specific sources.
+
+The mesh is yielded with its ``global_data`` updated in place.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, ClassVar
+
+import torch
+
+from physicsnemo_curator.core.base import Filter, Param
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from physicsnemo.mesh import Mesh
+
+logger = logging.getLogger(__name__)
+
+
+def _to_tensor(value: object) -> torch.Tensor:
+    """Coerce a scalar / sequence config value to a float32 tensor."""
+    if isinstance(value, torch.Tensor):
+        return value.to(torch.float32)
+    return torch.as_tensor(value, dtype=torch.float32)
+
+
+class GlobalDataFilter(Filter["Mesh"]):
+    """Inject constant ``global_data`` values into each mesh.
+
+    Each entry in *values* is converted to a float32 tensor and written to
+    the mesh's ``global_data`` (scalars become 0-d tensors, sequences become
+    1-d vectors).  For
+    :class:`~physicsnemo.mesh.domain_mesh.DomainMesh` objects the values are
+    written to the domain-level ``global_data``.
+
+    Parameters
+    ----------
+    values : dict
+        Mapping of ``global_data`` key to a scalar or sequence of floats
+        (e.g. ``{"U_inf": [30.0, 0.0, 0.0], "rho_inf": 1.225}``).
+    overwrite : bool
+        If ``True`` (default), overwrite existing keys; if ``False``, skip
+        keys already present.
+
+    Examples
+    --------
+    >>> filt = GlobalDataFilter(values={"U_inf": [30.0, 0.0, 0.0], "rho_inf": 1.225})  # doctest: +SKIP
+    >>> pipeline = source.filter(filt).write(sink)  # doctest: +SKIP
+    """
+
+    name: ClassVar[str] = "Global Data Injector"
+    description: ClassVar[str] = "Inject constant global_data values (e.g. freestream conditions) into meshes"
+
+    @classmethod
+    def params(cls) -> list[Param]:
+        """Return parameter descriptors for the filter.
+
+        Returns
+        -------
+        list[Param]
+            The ``values`` mapping and ``overwrite`` flag.
+        """
+        return [
+            Param(name="values", description="Mapping of global_data key to scalar or sequence", type=dict),
+            Param(name="overwrite", description="Overwrite existing global_data keys", type=bool, default=True),
+        ]
+
+    def __init__(self, values: dict[str, object], overwrite: bool = True) -> None:
+        if not values:
+            msg = "GlobalDataFilter requires a non-empty 'values' mapping."
+            raise ValueError(msg)
+        self._values: dict[str, torch.Tensor] = {str(k): _to_tensor(v) for k, v in values.items()}
+        self._overwrite = overwrite
+
+    def __call__(self, items: Generator[Mesh]) -> Generator[Mesh]:
+        """Inject global data into each mesh and yield it.
+
+        Parameters
+        ----------
+        items : Generator[Mesh]
+            Stream of incoming meshes (Mesh or DomainMesh).
+
+        Yields
+        ------
+        Mesh
+            The same mesh with ``global_data`` updated.
+        """
+        for mesh in items:
+            self._inject(mesh.global_data)
+            yield mesh
+
+    def _inject(self, global_data: object) -> None:
+        """Write the configured values into a ``global_data`` TensorDict.
+
+        Parameters
+        ----------
+        global_data : TensorDict
+            The mesh's ``global_data`` (modified in place).
+        """
+        existing = set(global_data.keys())  # ty: ignore[unresolved-attribute]
+        for key, tensor in self._values.items():
+            if key in existing and not self._overwrite:
+                continue
+            global_data[key] = tensor  # ty: ignore[unresolved-attribute]

--- a/src/physicsnemo_curator/domains/mesh/filters/global_data.py
+++ b/src/physicsnemo_curator/domains/mesh/filters/global_data.py
@@ -121,8 +121,13 @@ class GlobalDataFilter(Filter["Mesh"]):
         global_data : TensorDict
             The mesh's ``global_data`` (modified in place).
         """
-        existing = set(global_data.keys())  # ty: ignore[unresolved-attribute]
+        from tensordict import TensorDictBase
+
+        if not isinstance(global_data, TensorDictBase):
+            logger.warning("GlobalDataFilter: global_data is not a TensorDict, skipping injection.")
+            return
+        existing = set(global_data.keys())
         for key, tensor in self._values.items():
             if key in existing and not self._overwrite:
                 continue
-            global_data[key] = tensor  # ty: ignore[unresolved-attribute]
+            global_data[key] = tensor

--- a/src/physicsnemo_curator/domains/mesh/filters/point_data_to_cell.py
+++ b/src/physicsnemo_curator/domains/mesh/filters/point_data_to_cell.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Point-data to cell-data conversion filter for mesh pipelines.
+
+Wraps :meth:`physicsnemo.mesh.Mesh.point_data_to_cell_data` to move vertex
+fields onto cells (averaging over each cell's vertices).  Useful for surface
+boundary meshes that should carry cell-centered quantities.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, ClassVar
+
+from physicsnemo_curator.core.base import Filter, Param
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from physicsnemo.mesh import Mesh
+
+logger = logging.getLogger(__name__)
+
+
+class PointDataToCellDataFilter(Filter["Mesh"]):
+    """Convert ``point_data`` to ``cell_data`` by per-cell averaging.
+
+    For each incoming mesh with cells and point data, the average of each
+    point field over a cell's vertices is written to ``cell_data``.  By
+    default the original ``point_data`` is then dropped so the mesh carries
+    only cell-centered quantities (surface-boundary convention); set
+    *drop_point_data* to ``False`` to keep both.
+
+    For :class:`~physicsnemo.mesh.domain_mesh.DomainMesh` objects the
+    conversion is applied to the interior and every boundary sub-mesh that
+    has cells and point data.
+
+    Parameters
+    ----------
+    overwrite_keys : bool
+        If ``True``, overwrite existing ``cell_data`` keys; otherwise raise
+        on conflict.  Default ``False``.
+    drop_point_data : bool
+        If ``True`` (default), remove ``point_data`` after conversion.
+
+    Examples
+    --------
+    >>> filt = PointDataToCellDataFilter()  # doctest: +SKIP
+    >>> pipeline = source.filter(filt).write(sink)  # doctest: +SKIP
+    """
+
+    name: ClassVar[str] = "Point Data to Cell Data"
+    description: ClassVar[str] = "Move point_data onto cells by per-cell averaging"
+
+    @classmethod
+    def params(cls) -> list[Param]:
+        """Return parameter descriptors for the filter.
+
+        Returns
+        -------
+        list[Param]
+            The ``overwrite_keys`` and ``drop_point_data`` parameters.
+        """
+        return [
+            Param(name="overwrite_keys", description="Overwrite existing cell_data keys", type=bool, default=False),
+            Param(name="drop_point_data", description="Drop point_data after conversion", type=bool, default=True),
+        ]
+
+    def __init__(self, overwrite_keys: bool = False, drop_point_data: bool = True) -> None:
+        self._overwrite_keys = overwrite_keys
+        self._drop_point_data = drop_point_data
+
+    def __call__(self, items: Generator[Mesh]) -> Generator[Mesh]:
+        """Convert point data to cell data for each mesh in the stream.
+
+        Parameters
+        ----------
+        items : Generator[Mesh]
+            Stream of incoming meshes (Mesh or DomainMesh).
+
+        Yields
+        ------
+        Mesh
+            Mesh with cell data populated from point data.
+        """
+        from physicsnemo.mesh.domain_mesh import DomainMesh as _DomainMesh
+
+        for mesh in items:
+            if isinstance(mesh, _DomainMesh):
+                yield self._convert_domain_mesh(mesh)
+            else:
+                yield self._convert_mesh(mesh)
+
+    def _convert_mesh(self, mesh: Mesh) -> Mesh:
+        """Convert a single Mesh's point data to cell data.
+
+        Parameters
+        ----------
+        mesh : Mesh
+            The mesh to convert.
+
+        Returns
+        -------
+        Mesh
+            Converted mesh, or the original when it has no cells / point data.
+        """
+        if mesh.cells is None or mesh.n_cells == 0:
+            return mesh
+        if mesh.point_data is None or len(mesh.point_data.keys()) == 0:
+            return mesh
+
+        converted = mesh.point_data_to_cell_data(overwrite_keys=self._overwrite_keys)
+        if self._drop_point_data and converted.point_data is not None:
+            for key in list(converted.point_data.keys()):  # noqa: SIM118 - TensorDict needs .keys()
+                del converted.point_data[key]
+        return converted
+
+    def _convert_domain_mesh(self, domain_mesh: object) -> object:
+        """Convert all sub-meshes of a DomainMesh.
+
+        Parameters
+        ----------
+        domain_mesh : DomainMesh
+            The domain mesh to convert.
+
+        Returns
+        -------
+        DomainMesh
+            A new domain mesh with converted sub-meshes.
+        """
+        from physicsnemo.mesh.domain_mesh import DomainMesh as _DomainMesh
+
+        interior = self._convert_mesh(domain_mesh.interior)  # ty: ignore[unresolved-attribute]
+        boundaries = domain_mesh.boundaries  # ty: ignore[unresolved-attribute]
+        new_boundaries = {}
+        if boundaries is not None:
+            for name in boundaries.keys():  # noqa: SIM118 - TensorDict needs .keys()
+                new_boundaries[str(name)] = self._convert_mesh(boundaries[name])
+        return _DomainMesh(
+            interior=interior,
+            boundaries=new_boundaries,
+            global_data=domain_mesh.global_data,  # ty: ignore[unresolved-attribute]
+        )

--- a/src/physicsnemo_curator/domains/mesh/filters/stats.py
+++ b/src/physicsnemo_curator/domains/mesh/filters/stats.py
@@ -536,7 +536,7 @@ class MeshStatsFilter(Filter["Mesh"]):
         import panel as pn
         from bokeh.models import HoverTool
 
-        hv.extension("bokeh")  # ty: ignore[too-many-positional-arguments]
+        hv.extension("bokeh")
         stat_columns: list[str] = [
             "index",
             "mean",

--- a/src/physicsnemo_curator/domains/mesh/sinks/__init__.py
+++ b/src/physicsnemo_curator/domains/mesh/sinks/__init__.py
@@ -18,7 +18,7 @@
 
 from physicsnemo_curator.domains.mesh.sinks.mesh_writer import MeshSink
 
-__all__ = ["MeshSink", "MeshVTUSink", "MeshZarrSink"]
+__all__ = ["GridSidecarSink", "MeshSink", "MeshVTUSink", "MeshZarrSink"]
 
 
 def __getattr__(name: str):
@@ -31,5 +31,9 @@ def __getattr__(name: str):
         from physicsnemo_curator.domains.mesh.sinks.mesh_vtu import MeshVTUSink
 
         return MeshVTUSink
+    if name == "GridSidecarSink":
+        from physicsnemo_curator.domains.mesh.sinks.grid_sidecar import GridSidecarSink
+
+        return GridSidecarSink
     msg = f"module {__name__!r} has no attribute {name!r}"
     raise AttributeError(msg)

--- a/src/physicsnemo_curator/domains/mesh/sinks/grid_sidecar.py
+++ b/src/physicsnemo_curator/domains/mesh/sinks/grid_sidecar.py
@@ -1,0 +1,208 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Structured-grid sidecar sink.
+
+Persists structured-grid :class:`tensordict.TensorDict` objects (produced by
+:class:`~physicsnemo_curator.domains.mesh.sources.vti.VTISource`) to disk as
+tensordict memmap directories.  Output is written as a **sidecar**: by
+default the source's directory layout is mirrored under *output_dir* using
+the ``{relpath}/{stem}`` naming, so each grid lands next to the mesh
+(``.pmsh`` / ``.pdmsh``) outputs for the same sample.
+
+Reload with :meth:`tensordict.TensorDict.load_memmap`.
+"""
+
+from __future__ import annotations
+
+import logging
+import pathlib
+from typing import TYPE_CHECKING, ClassVar
+
+from physicsnemo_curator.core.base import Param, Sink
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from tensordict import TensorDict
+
+    from physicsnemo_curator.core.base import Source
+
+logger = logging.getLogger(__name__)
+
+#: Default output suffix for grid sidecar directories.
+_GRID_SUFFIX = ".grid"
+
+
+class GridSidecarSink(Sink["TensorDict"]):
+    """Write structured-grid TensorDicts as tensordict memmap sidecars.
+
+    Each grid is written to a ``<name>.grid`` directory under *output_dir*.
+    When the pipeline source exposes ``relative_path(index)`` (e.g.
+    :class:`~physicsnemo_curator.domains.mesh.sources.vti.VTISource`), the
+    default ``{relpath}/{stem}`` template mirrors the input layout so the
+    grid sits beside the corresponding mesh outputs.
+
+    Parameters
+    ----------
+    output_dir : str
+        Directory where grid sidecars will be written.
+    naming_template : str or None
+        Format string for output names.  Placeholders: ``{index}``,
+        ``{seq}``, ``{relpath}``, ``{stem}``.  Default ``"{relpath}/{stem}"``
+        when the source supports it, else ``"grid_{index:04d}_{seq}"``.
+    group_readable : bool
+        If ``True``, ``chmod g+r`` the written output.
+
+    Examples
+    --------
+    >>> pipeline = VTISource("./grids/").write(GridSidecarSink(output_dir="./out/"))  # doctest: +SKIP
+    """
+
+    name: ClassVar[str] = "Grid Sidecar Writer"
+    description: ClassVar[str] = "Write structured-grid TensorDicts as tensordict memmap sidecars"
+
+    @classmethod
+    def params(cls) -> list[Param]:
+        """Return parameter descriptors for the grid sidecar sink.
+
+        Returns
+        -------
+        list[Param]
+            The ``output_dir``, ``naming_template``, and ``group_readable``
+            parameters.
+        """
+        return [
+            Param(name="output_dir", description="Output directory for grid sidecars", type=str),
+            Param(
+                name="naming_template",
+                description="Format string for output names ({index}, {seq}, {relpath}, {stem})",
+                type=str,
+                default=None,
+            ),
+            Param(
+                name="group_readable",
+                description="Make written outputs group-readable (chmod g+r)",
+                type=bool,
+                default=False,
+            ),
+        ]
+
+    def __init__(
+        self,
+        output_dir: str,
+        naming_template: str | None = None,
+        group_readable: bool = False,
+    ) -> None:
+        from physicsnemo_curator.core.logging import get_logger
+
+        self._output_dir = pathlib.Path(output_dir)
+        self._naming_template = naming_template
+        self._group_readable = group_readable
+        self._source: Source[TensorDict] | None = None
+        self._log = get_logger(self)
+
+        if naming_template is not None:
+            try:
+                naming_template.format(index=0, seq=0, relpath="test", stem="test")
+            except (KeyError, IndexError, ValueError) as exc:
+                msg = (
+                    f"Invalid naming_template {naming_template!r}: {exc}. "
+                    "Only {index}, {seq}, {relpath}, and {stem} placeholders are supported."
+                )
+                raise ValueError(msg) from exc
+
+    def set_source(self, source: Source[TensorDict]) -> None:
+        """Inject the pipeline source for placeholder resolution.
+
+        Parameters
+        ----------
+        source : Source[TensorDict]
+            The pipeline source.  ``relative_path(index)`` is used when
+            available to resolve ``{relpath}`` / ``{stem}``.
+        """
+        self._source = source
+
+    def __call__(self, items: Iterator[TensorDict], index: int) -> list[str]:
+        """Write structured-grid TensorDicts to memmap sidecars.
+
+        Parameters
+        ----------
+        items : Iterator[TensorDict]
+            Stream of grid TensorDicts to persist.
+        index : int
+            Source index (used for naming).
+
+        Returns
+        -------
+        list[str]
+            Paths of the written sidecar directories.
+        """
+        import shutil
+        import tempfile
+        import time
+
+        self._output_dir.mkdir(parents=True, exist_ok=True)
+        paths: list[str] = []
+
+        relpath = ""
+        stem = ""
+        has_relpath = self._source is not None and hasattr(self._source, "relative_path")
+        if has_relpath:
+            rel = self._source.relative_path(index)  # ty: ignore[union-attr]
+            rel_path = pathlib.PurePosixPath(rel)
+            stem = rel_path.stem
+            relpath = str(rel_path.parent) if str(rel_path.parent) != "." else ""
+
+        for seq, grid in enumerate(items):
+            if self._naming_template is not None:
+                name = self._naming_template.format(index=index, seq=seq, relpath=relpath, stem=stem)
+            elif has_relpath:
+                name = f"{relpath}/{stem}" if relpath else stem
+            else:
+                name = f"grid_{index:04d}_{seq}"
+
+            if not name.endswith(_GRID_SUFFIX):
+                name = name + _GRID_SUFFIX
+
+            subdir = self._output_dir / name
+            subdir.parent.mkdir(parents=True, exist_ok=True)
+
+            t0 = time.perf_counter()
+            tmp_dir = tempfile.mkdtemp(prefix=".tmp_", dir=str(subdir.parent))
+            try:
+                grid.memmap(tmp_dir)
+                if subdir.exists():
+                    shutil.rmtree(subdir)
+                pathlib.Path(tmp_dir).replace(subdir)
+            except BaseException:
+                shutil.rmtree(tmp_dir, ignore_errors=True)
+                raise
+
+            if self._group_readable:
+                from physicsnemo_curator.domains.mesh.sinks.mesh_writer import _fix_group_readable
+
+                _fix_group_readable(subdir)
+
+            self._log.debug("idx_%d: Saved grid to %s (%.2fs)", index, subdir, time.perf_counter() - t0)
+            paths.append(str(subdir))
+
+        return paths
+
+    @property
+    def output_dir(self) -> pathlib.Path:
+        """Return the output directory path."""
+        return self._output_dir

--- a/src/physicsnemo_curator/domains/mesh/sinks/grid_sidecar.py
+++ b/src/physicsnemo_curator/domains/mesh/sinks/grid_sidecar.py
@@ -161,8 +161,8 @@ class GridSidecarSink(Sink["TensorDict"]):
         relpath = ""
         stem = ""
         has_relpath = self._source is not None and hasattr(self._source, "relative_path")
-        if has_relpath:
-            rel = self._source.relative_path(index)  # ty: ignore[union-attr]
+        if has_relpath and self._source is not None:
+            rel = self._source.relative_path(index)  # ty: ignore[unresolved-attribute]
             rel_path = pathlib.PurePosixPath(rel)
             stem = rel_path.stem
             relpath = str(rel_path.parent) if str(rel_path.parent) != "." else ""

--- a/src/physicsnemo_curator/domains/mesh/sinks/mesh_writer.py
+++ b/src/physicsnemo_curator/domains/mesh/sinks/mesh_writer.py
@@ -41,6 +41,33 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _fix_group_readable(root: pathlib.Path) -> None:
+    """Ensure *root* and everything inside it is group-readable.
+
+    Adds the group-read bit to all files and the group-read + execute bits
+    to all directories under *root* (so the group can traverse and read the
+    tensordict memmap tree).
+
+    Parameters
+    ----------
+    root : pathlib.Path
+        Root directory (or file) to make group-readable.
+    """
+    import os
+    import stat
+
+    if root.is_file():
+        root.chmod(root.stat().st_mode | stat.S_IRGRP)
+        return
+
+    for dirpath, _dirnames, filenames in os.walk(root):
+        dp = pathlib.Path(dirpath)
+        dp.chmod(dp.stat().st_mode | stat.S_IRGRP | stat.S_IXGRP)
+        for fn in filenames:
+            fp = dp / fn
+            fp.chmod(fp.stat().st_mode | stat.S_IRGRP)
+
+
 class MeshSink(Sink["Mesh"]):
     """Write :class:`~physicsnemo.mesh.Mesh` and :class:`~physicsnemo.mesh.domain_mesh.DomainMesh` objects to disk.
 
@@ -130,7 +157,8 @@ class MeshSink(Sink["Mesh"]):
         Returns
         -------
         list[Param]
-            The ``output_dir`` and optional ``naming_template`` parameters.
+            The ``output_dir``, optional ``naming_template``, and
+            ``group_readable`` parameters.
         """
         return [
             Param(name="output_dir", description="Output directory for mesh files", type=str),
@@ -144,12 +172,19 @@ class MeshSink(Sink["Mesh"]):
                 type=str,
                 default=None,
             ),
+            Param(
+                name="group_readable",
+                description="Make written outputs group-readable (chmod g+r)",
+                type=bool,
+                default=False,
+            ),
         ]
 
     def __init__(
         self,
         output_dir: str,
         naming_template: str | None = None,
+        group_readable: bool = False,
     ) -> None:
         """Initialise the mesh sink.
 
@@ -160,6 +195,9 @@ class MeshSink(Sink["Mesh"]):
         naming_template : str or None
             Python format string for subdirectory names.  See the class
             docstring for details.
+        group_readable : bool
+            If ``True``, ``chmod g+r`` (and ``g+x`` on directories) the
+            written output so it is readable by the owning group.
 
         Raises
         ------
@@ -170,6 +208,7 @@ class MeshSink(Sink["Mesh"]):
 
         self._output_dir = pathlib.Path(output_dir)
         self._naming_template = naming_template
+        self._group_readable = group_readable
         self._source: Source[Mesh] | None = None
         self._log = get_logger(self)
 
@@ -220,6 +259,8 @@ class MeshSink(Sink["Mesh"]):
         list[str]
             Paths of the saved mesh directories.
         """
+        import shutil
+        import tempfile
         import time
 
         from physicsnemo.mesh.domain_mesh import DomainMesh as _DomainMesh
@@ -286,7 +327,22 @@ class MeshSink(Sink["Mesh"]):
             subdir.parent.mkdir(parents=True, exist_ok=True)
 
             t0 = time.perf_counter()
-            mesh.save(str(subdir))
+            # Write to a temp directory in the same parent, then atomically
+            # rename into place so an interrupted write never leaves a
+            # partial/corrupt output directory behind.
+            tmp_dir = tempfile.mkdtemp(prefix=".tmp_", dir=str(subdir.parent))
+            try:
+                mesh.save(tmp_dir)
+                if subdir.exists():
+                    shutil.rmtree(subdir)
+                pathlib.Path(tmp_dir).replace(subdir)
+            except BaseException:
+                shutil.rmtree(tmp_dir, ignore_errors=True)
+                raise
+
+            if self._group_readable:
+                _fix_group_readable(subdir)
+
             self._log.debug(
                 "idx_%d: Saved %s to %s (%.2fs)",
                 index,

--- a/src/physicsnemo_curator/domains/mesh/sources/_key_filter.py
+++ b/src/physicsnemo_curator/domains/mesh/sources/_key_filter.py
@@ -1,0 +1,166 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Path-pattern rules for per-file VTK conversion.
+
+Provides two small rule systems used by
+:class:`~physicsnemo_curator.domains.mesh.sources.vtk.VTKSource`:
+
+* :class:`KeyFilterRule` — per-path-glob data-array include/exclude rules,
+  applied at the VTK reader level so unwanted fields are never materialised.
+* :func:`resolve_path_value` — resolve a setting (e.g. ``manifold_dim`` or
+  ``point_source``) that may be a single scalar applied to every file, or a
+  list of ``{"pattern": glob, "value": ...}`` rules selected by file path
+  (longest matching pattern wins).
+
+Matching uses :func:`fnmatch.fnmatch` against the full file path string.  When
+several patterns match, the longest pattern string is treated as most
+specific.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class KeyFilterRule:
+    """A single data-array filter rule matched by file-path glob.
+
+    Attributes
+    ----------
+    path_pattern : str
+        Glob pattern matched against the source file path (e.g.
+        ``"**/*.vtp"``, ``"**/volume_*.vtu"``).
+    mode : {"include", "exclude"}
+        ``"include"`` keeps only the listed arrays; ``"exclude"`` drops them.
+    keys : list[str]
+        Data-array names to include or exclude.
+    """
+
+    path_pattern: str
+    mode: Literal["include", "exclude"]
+    keys: list[str] = field(default_factory=list)
+
+
+def rules_from_config(raw: list[dict] | None) -> list[KeyFilterRule]:
+    """Build :class:`KeyFilterRule` objects from raw config dicts.
+
+    Parameters
+    ----------
+    raw : list[dict] or None
+        Each dict must have ``path_pattern``, ``mode``, and ``keys`` fields.
+
+    Returns
+    -------
+    list[KeyFilterRule]
+        Parsed rules (empty list when *raw* is falsy).
+    """
+    if not raw:
+        return []
+    return [
+        KeyFilterRule(
+            path_pattern=entry["path_pattern"],
+            mode=entry["mode"],
+            keys=list(entry.get("keys", [])),
+        )
+        for entry in raw
+    ]
+
+
+def match_filter(file_path: str, rules: list[KeyFilterRule]) -> KeyFilterRule | None:
+    """Return the most specific filter rule matching *file_path*.
+
+    Among all rules whose ``path_pattern`` matches, the one with the longest
+    pattern string is selected.
+
+    Parameters
+    ----------
+    file_path : str
+        File path to match.
+    rules : list[KeyFilterRule]
+        Candidate rules.
+
+    Returns
+    -------
+    KeyFilterRule or None
+        The matching rule, or ``None`` if none match.
+    """
+    matches = [rule for rule in rules if fnmatch.fnmatch(file_path, rule.path_pattern)]
+    if not matches:
+        return None
+    matches.sort(key=lambda r: len(r.path_pattern), reverse=True)
+    return matches[0]
+
+
+def resolve_arrays(
+    file_path: str,
+    rules: list[KeyFilterRule],
+) -> tuple[list[str] | None, list[str] | None]:
+    """Resolve ``(include_arrays, exclude_arrays)`` for *file_path*.
+
+    Parameters
+    ----------
+    file_path : str
+        File path to match.
+    rules : list[KeyFilterRule]
+        Candidate filter rules.
+
+    Returns
+    -------
+    tuple[list[str] | None, list[str] | None]
+        ``(include_arrays, exclude_arrays)`` — at most one is non-``None``.
+    """
+    rule = match_filter(file_path, rules)
+    if rule is None:
+        return None, None
+    if rule.mode == "include":
+        return list(rule.keys), None
+    return None, list(rule.keys)
+
+
+def resolve_path_value(spec: Any, file_path: str, *, default: Any = None) -> Any:
+    """Resolve a possibly per-path setting for *file_path*.
+
+    Parameters
+    ----------
+    spec : Any
+        Either a scalar value applied to every file, or a list of
+        ``{"pattern": glob, "value": ...}`` rule dicts.
+    file_path : str
+        File path to match against rule patterns.
+    default : Any
+        Value returned when *spec* is a rule list but no pattern matches.
+
+    Returns
+    -------
+    Any
+        The resolved value.
+    """
+    if not isinstance(spec, (list, tuple)):
+        return spec
+
+    matched: tuple[int, Any] | None = None
+    for entry in spec:
+        pattern = entry["pattern"]
+        if fnmatch.fnmatch(file_path, pattern) and (matched is None or len(pattern) > matched[0]):
+            matched = (len(pattern), entry["value"])
+    return matched[1] if matched is not None else default

--- a/src/physicsnemo_curator/domains/mesh/sources/_vtk_convert.py
+++ b/src/physicsnemo_curator/domains/mesh/sources/_vtk_convert.py
@@ -1,0 +1,620 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared, dataset-agnostic VTK -> physicsnemo Mesh conversion helpers.
+
+This module centralises the VTK reading and conversion mechanics that are
+otherwise duplicated between
+:class:`~physicsnemo_curator.domains.mesh.sources.vtk.VTKSource` and
+:class:`~physicsnemo_curator.domains.mesh.sources.drivaerml.DrivAerMLSource`.
+
+It supports two backends:
+
+* **pyvista** — full-featured reading via :func:`physicsnemo.mesh.io.from_pyvista`
+  with optional reader-level data-array filtering (``vtkXML*Reader`` array
+  selection) to avoid materialising unwanted fields.
+* **rust** — the native ``physicsnemo_curator._lib.vtk`` reader (ASCII/binary
+  VTU/VTP only) for fast I/O, building a :class:`~physicsnemo.mesh.Mesh`
+  directly from raw NumPy arrays.
+
+The conversion supports both point sources (mesh ``vertices`` or
+``cell_centroids``), polygon tessellation for mixed surface cells, and an
+optional float64 -> float32 downcast.
+"""
+
+from __future__ import annotations
+
+import logging
+import pathlib
+from typing import TYPE_CHECKING, Any, Literal
+
+import numpy as np
+import torch
+from physicsnemo.mesh import Mesh
+
+if TYPE_CHECKING:
+    import pyvista as pv
+
+logger = logging.getLogger(__name__)
+
+#: VTK reading backend identifiers.
+Backend = Literal["pyvista", "rust"]
+
+#: File extensions the Rust reader can parse (VTK XML formats).
+_RUST_EXTENSIONS: frozenset[str] = frozenset({".vtu", ".vtp"})
+
+#: VTK XML reader class names per extension (for reader-level array filtering).
+_XML_READERS: dict[str, str] = {
+    ".vtu": "vtkXMLUnstructuredGridReader",
+    ".vtp": "vtkXMLPolyDataReader",
+}
+
+
+# ---------------------------------------------------------------------------
+# Backend selection
+# ---------------------------------------------------------------------------
+
+
+def can_use_rust(
+    path: str | pathlib.Path,
+    point_source: str,
+    manifold_dim: int | Literal["auto"],
+) -> bool:
+    """Return ``True`` if the Rust reader can handle this file + config.
+
+    Parameters
+    ----------
+    path : str or pathlib.Path
+        Path to the VTK file.
+    point_source : str
+        Point-source mode (``"vertices"`` or ``"cell_centroids"``).
+    manifold_dim : int or {"auto"}
+        Target manifold dimension.
+
+    Returns
+    -------
+    bool
+        ``True`` when the file extension is a Rust-supported VTK XML format
+        and the requested conversion is expressible without PyVista.
+    """
+    suffix = pathlib.Path(path).suffix.lower()
+    if suffix not in _RUST_EXTENSIONS:
+        return False
+    # The dual-graph (cell_centroids + manifold_dim=1) construction requires
+    # face-adjacency that the Rust reader does not expose; defer to PyVista.
+    return not (point_source == "cell_centroids" and manifold_dim == 1)
+
+
+# ---------------------------------------------------------------------------
+# Cell / connectivity helpers
+# ---------------------------------------------------------------------------
+
+
+def build_cells_from_rust(rust_data: Any) -> torch.Tensor | None:
+    """Build a uniform ``(n_cells, nodes_per_cell)`` cell tensor.
+
+    Returns ``None`` when the mesh has no cells or contains mixed cell
+    types (non-uniform vertex counts), which cannot be packed into a
+    rectangular tensor.
+
+    Parameters
+    ----------
+    rust_data : VtkMeshData
+        Parsed VTK data from the Rust reader.
+
+    Returns
+    -------
+    torch.Tensor or None
+        Cell connectivity of shape ``(n_cells, nodes_per_cell)`` (dtype
+        ``int64``), or ``None`` if unavailable / mixed.
+    """
+    connectivity = rust_data.cells
+    offsets = rust_data.cell_offsets
+    n_cells = rust_data.n_cells
+
+    if connectivity is None or offsets is None or connectivity.size == 0 or n_cells == 0:
+        return None
+
+    if offsets.size > 1:
+        nodes_per_cell = int(offsets[1] - offsets[0])
+    elif connectivity.size > 0:
+        nodes_per_cell = connectivity.size // n_cells
+    else:
+        return None
+
+    if nodes_per_cell <= 0 or connectivity.size != n_cells * nodes_per_cell:
+        # Mixed cell types — cannot form a uniform tensor.
+        return None
+
+    return torch.from_numpy(np.ascontiguousarray(connectivity)).reshape(n_cells, nodes_per_cell).to(torch.int64)
+
+
+def _offset_starts_ends(offsets: np.ndarray, n_cells: int) -> tuple[np.ndarray, np.ndarray]:
+    """Normalise VTK cell offsets into per-cell ``(starts, ends)`` arrays.
+
+    Accepts either the VTK convention where ``offsets`` holds the cumulative
+    *end* index of each cell (length ``n_cells``) or the ``n_cells + 1``
+    convention with a leading ``0``.
+
+    Parameters
+    ----------
+    offsets : numpy.ndarray
+        Cell offset array.
+    n_cells : int
+        Number of cells.
+
+    Returns
+    -------
+    tuple[numpy.ndarray, numpy.ndarray]
+        ``(starts, ends)`` index arrays, each of length ``n_cells``.
+    """
+    offs = np.asarray(offsets, dtype=np.int64)
+    if offs.size == n_cells:
+        starts = np.empty(n_cells, dtype=np.int64)
+        starts[0] = 0
+        starts[1:] = offs[:-1]
+        ends = offs
+    else:
+        starts = offs[:-1]
+        ends = offs[1:]
+    return starts, ends
+
+
+def compute_centroids_from_rust(rust_data: Any) -> torch.Tensor:
+    """Compute per-cell centroids from Rust connectivity.
+
+    Uses a fast vectorised path for uniform cell types and a scatter-add
+    path for mixed polyhedral / polygonal meshes.
+
+    Parameters
+    ----------
+    rust_data : VtkMeshData
+        Parsed VTK data from the Rust reader.  Must have cells.
+
+    Returns
+    -------
+    torch.Tensor
+        Centroid coordinates of shape ``(n_cells, 3)``.
+
+    Raises
+    ------
+    ValueError
+        If the mesh has no cell connectivity.
+    """
+    n_cells = rust_data.n_cells
+    connectivity = rust_data.cells
+    offsets = rust_data.cell_offsets
+
+    if connectivity is None or connectivity.size == 0 or n_cells == 0:
+        raise ValueError("point_source='cell_centroids' requires cells, but the file has none.")
+
+    points = torch.from_numpy(np.ascontiguousarray(rust_data.points))
+
+    starts, ends = _offset_starts_ends(offsets, n_cells)
+    nodes_per_cell = ends - starts
+    nodes_first = int(nodes_per_cell[0]) if nodes_per_cell.size > 0 else 0
+
+    if nodes_first > 0 and connectivity.size == n_cells * nodes_first:
+        # Uniform cell type — fast vectorised gather + mean.
+        conn = torch.from_numpy(np.ascontiguousarray(connectivity)).reshape(n_cells, nodes_first).to(torch.int64)
+        return points[conn].mean(dim=1)
+
+    # Mixed cell types — scatter-add each node's coords into its cell, then
+    # divide by the per-cell node count.
+    conn_t = torch.from_numpy(np.ascontiguousarray(connectivity)).to(torch.int64)
+    all_pts = points[conn_t]  # (total_nodes, 3)
+    cell_ids = np.repeat(np.arange(n_cells, dtype=np.int64), nodes_per_cell)
+    cell_ids_t = torch.from_numpy(cell_ids).unsqueeze(1).expand(-1, points.shape[1])
+    centroids = torch.zeros(n_cells, points.shape[1], dtype=points.dtype)
+    centroids.scatter_add_(0, cell_ids_t, all_pts)
+    npc_t = torch.from_numpy(nodes_per_cell.astype(np.float64)).to(points.dtype)
+    centroids /= npc_t.unsqueeze(1).clamp_min(1)
+    return centroids
+
+
+def tessellate_polygons(
+    connectivity: Any,
+    offsets: Any,
+    n_cells: int,
+) -> torch.Tensor:
+    """Fan-tessellate mixed polygons into triangles.
+
+    A polygon with *k* vertices produces *k - 2* triangles via fan
+    triangulation from its first vertex.
+
+    Parameters
+    ----------
+    connectivity : numpy.ndarray
+        Flat connectivity array (vertex indices for all cells).
+    offsets : numpy.ndarray
+        Per-cell offsets into *connectivity* (VTK convention).
+    n_cells : int
+        Number of polygons.
+
+    Returns
+    -------
+    torch.Tensor
+        Triangle cells of shape ``(n_triangles, 3)`` with dtype ``int64``.
+    """
+    conn = np.asarray(connectivity, dtype=np.int64)
+    starts, ends = _offset_starts_ends(offsets, n_cells)
+
+    n_verts = ends - starts
+    n_tris_per_cell = n_verts - 2
+    total_tris = int(n_tris_per_cell.sum())
+
+    cell_of_tri = np.repeat(np.arange(n_cells, dtype=np.int64), n_tris_per_cell)
+    local_j = np.arange(total_tris, dtype=np.int64)
+    cum_tris = np.zeros(n_cells + 1, dtype=np.int64)
+    np.cumsum(n_tris_per_cell, out=cum_tris[1:])
+    local_j -= cum_tris[cell_of_tri]
+
+    poly_starts = starts[cell_of_tri]
+
+    triangles = np.empty((total_tris, 3), dtype=np.int64)
+    triangles[:, 0] = conn[poly_starts]
+    triangles[:, 1] = conn[poly_starts + local_j + 1]
+    triangles[:, 2] = conn[poly_starts + local_j + 2]
+
+    return torch.from_numpy(triangles)
+
+
+def expand_cell_data_for_tessellation(
+    cell_data_dict: dict[str, torch.Tensor],
+    offsets: Any,
+    n_cells: int,
+) -> dict[str, torch.Tensor]:
+    """Repeat cell-data entries to match tessellated triangles.
+
+    When a polygon with *k* vertices is split into *k - 2* triangles, its
+    cell-data value is repeated *k - 2* times.
+
+    Parameters
+    ----------
+    cell_data_dict : dict[str, torch.Tensor]
+        Mapping of field name to tensor of shape ``(n_cells, ...)``.
+    offsets : numpy.ndarray
+        Cell offsets (same convention as :func:`tessellate_polygons`).
+    n_cells : int
+        Number of original polygons.
+
+    Returns
+    -------
+    dict[str, torch.Tensor]
+        Expanded cell data with shape ``(n_triangles, ...)``.
+    """
+    starts, ends = _offset_starts_ends(offsets, n_cells)
+    n_tris_per_cell = (ends - starts - 2).astype(np.int64)
+    repeat_counts = torch.from_numpy(n_tris_per_cell)
+    return {name: torch.repeat_interleave(tensor, repeat_counts, dim=0) for name, tensor in cell_data_dict.items()}
+
+
+# ---------------------------------------------------------------------------
+# Precision
+# ---------------------------------------------------------------------------
+
+
+def downcast_fp32(mesh: Mesh) -> Mesh:
+    """Downcast float64 tensors in a Mesh to float32 in place.
+
+    Parameters
+    ----------
+    mesh : Mesh
+        Input mesh (modified in place).
+
+    Returns
+    -------
+    Mesh
+        The same mesh with float64 arrays converted to float32.
+    """
+    if mesh.points is not None and mesh.points.dtype == torch.float64:
+        mesh.points = mesh.points.float()
+
+    for store in (mesh.point_data, mesh.cell_data):
+        if store is None:
+            continue
+        for key in list(store.keys()):  # noqa: SIM118 - TensorDict needs .keys()
+            tensor = store[key]
+            if isinstance(tensor, torch.Tensor) and tensor.dtype == torch.float64:
+                store[key] = tensor.float()
+
+    return mesh
+
+
+# ---------------------------------------------------------------------------
+# Rust VtkMeshData -> Mesh
+# ---------------------------------------------------------------------------
+
+
+def _arrays_to_dict(arrays: dict[str, np.ndarray]) -> dict[str, torch.Tensor]:
+    """Convert a ``{name: ndarray}`` mapping to ``{name: tensor}``."""
+    return {name: torch.from_numpy(np.ascontiguousarray(data)) for name, data in arrays.items()}
+
+
+def mesh_from_rust_data(
+    rust_data: Any,
+    *,
+    manifold_dim: int | Literal["auto"] = "auto",
+    point_source: str = "vertices",
+    fp32: bool = False,
+    tessellate_surface: bool = False,
+    cell_data_only: bool = False,
+) -> Mesh:
+    """Build a :class:`~physicsnemo.mesh.Mesh` from Rust ``VtkMeshData``.
+
+    Parameters
+    ----------
+    rust_data : VtkMeshData
+        Parsed VTK data from ``physicsnemo_curator._lib.vtk.read_vtk``.
+    manifold_dim : int or {"auto"}
+        Target manifold dimension (only used for ``point_source="vertices"``).
+        ``"auto"`` resolves to 2 when cells are present, else 0.
+    point_source : {"vertices", "cell_centroids"}
+        ``"vertices"`` keeps mesh vertices and ``point_data``; ``"cell_centroids"``
+        builds a point cloud from cell centroids and maps ``cell_data`` to
+        ``point_data``.
+    fp32 : bool
+        If ``True``, downcast float64 arrays to float32.
+    tessellate_surface : bool
+        If ``True`` and the mesh has mixed-type surface cells, fan-tessellate
+        polygons into triangles (and expand cell data accordingly).
+    cell_data_only : bool
+        If ``True`` (surface meshes), drop ``point_data`` and keep only
+        ``cell_data``.
+
+    Returns
+    -------
+    Mesh
+        The converted mesh.
+    """
+    if point_source == "cell_centroids":
+        centroids = compute_centroids_from_rust(rust_data)
+        point_data = _arrays_to_dict(rust_data.cell_data)
+        mesh = Mesh(points=centroids, cells=None, point_data=point_data or None)
+        return downcast_fp32(mesh) if fp32 else mesh
+
+    points = torch.from_numpy(np.ascontiguousarray(rust_data.points))
+    point_data = None if cell_data_only else _arrays_to_dict(rust_data.point_data)
+
+    resolved_dim = manifold_dim
+    if resolved_dim == "auto":
+        resolved_dim = 2 if (rust_data.cells is not None and rust_data.n_cells > 0) else 0
+
+    has_cells = rust_data.cells is not None and rust_data.n_cells > 0
+    if resolved_dim == 0 or not has_cells:
+        mesh = Mesh(points=points, cells=None, point_data=point_data or None)
+        return downcast_fp32(mesh) if fp32 else mesh
+
+    cells = build_cells_from_rust(rust_data)
+    cell_data = _arrays_to_dict(rust_data.cell_data)
+
+    if cells is None:
+        # Mixed cell types.
+        if tessellate_surface:
+            cells = tessellate_polygons(rust_data.cells, rust_data.cell_offsets, rust_data.n_cells)
+            cell_data = expand_cell_data_for_tessellation(cell_data, rust_data.cell_offsets, rust_data.n_cells)
+        else:
+            logger.warning(
+                "Mesh has mixed cell types and tessellate_surface=False; dropping cells/cell_data.",
+            )
+            cell_data = {}
+
+    mesh = Mesh(
+        points=points,
+        cells=cells,
+        point_data=point_data or None,
+        cell_data=cell_data or None,
+    )
+    return downcast_fp32(mesh) if fp32 else mesh
+
+
+# ---------------------------------------------------------------------------
+# PyVista reading
+# ---------------------------------------------------------------------------
+
+
+def read_pyvista_dataset(
+    path: str | pathlib.Path,
+    *,
+    include_arrays: list[str] | None = None,
+    exclude_arrays: list[str] | None = None,
+) -> pv.DataSet:
+    """Read a VTK file with PyVista, optionally filtering data arrays.
+
+    When *include_arrays* or *exclude_arrays* is given and the file is a VTK
+    XML format (``.vtu`` / ``.vtp``), array selection is applied at the
+    reader level so unwanted fields are never materialised.  Otherwise this
+    is a plain :func:`pyvista.read`.
+
+    Parameters
+    ----------
+    path : str or pathlib.Path
+        Path to the VTK file.
+    include_arrays : list[str] or None
+        If given, keep only these named point/cell data arrays.
+    exclude_arrays : list[str] or None
+        If given, drop these named point/cell data arrays.
+
+    Returns
+    -------
+    pyvista.DataSet
+        The loaded dataset.
+    """
+    import pyvista as pv
+
+    path = str(path)
+    suffix = pathlib.Path(path).suffix.lower()
+    reader_name = _XML_READERS.get(suffix)
+
+    if (include_arrays is None and exclude_arrays is None) or reader_name is None:
+        return pv.read(path)
+
+    import vtk as _vtk
+
+    reader = getattr(_vtk, reader_name)()
+    reader.SetFileName(path)
+    reader.UpdateInformation()
+
+    for selection in (reader.GetPointDataArraySelection(), reader.GetCellDataArraySelection()):
+        if include_arrays is not None:
+            selection.DisableAllArrays()
+            for key in include_arrays:
+                selection.EnableArray(key)
+        elif exclude_arrays is not None:
+            for key in exclude_arrays:
+                selection.DisableArray(key)
+
+    reader.Update()
+    return pv.wrap(reader.GetOutput())
+
+
+def mesh_from_pyvista(
+    path: str | pathlib.Path,
+    *,
+    manifold_dim: int | Literal["auto"] = "auto",
+    point_source: str = "vertices",
+    warn_on_lost_data: bool = True,
+    include_arrays: list[str] | None = None,
+    exclude_arrays: list[str] | None = None,
+    fp32: bool = False,
+    cell_data_only: bool = False,
+) -> Mesh:
+    """Read a VTK file via PyVista and convert to a Mesh.
+
+    Parameters
+    ----------
+    path : str or pathlib.Path
+        Path to the VTK file.
+    manifold_dim : int or {"auto"}
+        Target manifold dimension passed to ``from_pyvista``.
+    point_source : {"vertices", "cell_centroids"}
+        Point-source mode passed to ``from_pyvista``.
+    warn_on_lost_data : bool
+        Forwarded to ``from_pyvista``.
+    include_arrays, exclude_arrays : list[str] or None
+        Reader-level data-array filters (see :func:`read_pyvista_dataset`).
+    fp32 : bool
+        If ``True``, downcast float64 arrays to float32.
+    cell_data_only : bool
+        If ``True``, drop ``point_data`` after conversion (surface meshes).
+
+    Returns
+    -------
+    Mesh
+        The converted mesh.
+    """
+    from physicsnemo.mesh.io import from_pyvista
+
+    data = read_pyvista_dataset(path, include_arrays=include_arrays, exclude_arrays=exclude_arrays)
+    mesh = from_pyvista(
+        data,
+        manifold_dim=manifold_dim,
+        point_source=point_source,
+        warn_on_lost_data=warn_on_lost_data,
+    )
+    if cell_data_only and mesh.point_data is not None:
+        for key in list(mesh.point_data.keys()):  # noqa: SIM118 - TensorDict needs .keys()
+            del mesh.point_data[key]
+    return downcast_fp32(mesh) if fp32 else mesh
+
+
+# ---------------------------------------------------------------------------
+# Top-level orchestrator
+# ---------------------------------------------------------------------------
+
+
+def read_vtk_mesh(
+    path: str | pathlib.Path,
+    *,
+    backend: Backend = "pyvista",
+    manifold_dim: int | Literal["auto"] = "auto",
+    point_source: str = "vertices",
+    include_arrays: list[str] | None = None,
+    exclude_arrays: list[str] | None = None,
+    warn_on_lost_data: bool = True,
+    fp32: bool = False,
+    tessellate_surface: bool = False,
+    cell_data_only: bool = False,
+) -> Mesh:
+    """Read a VTK file into a Mesh using the requested backend.
+
+    When ``backend="rust"`` and the file/config are Rust-compatible (see
+    :func:`can_use_rust`), the native reader is used with a transparent
+    fallback to PyVista on any failure.  Otherwise PyVista is used directly.
+
+    Parameters
+    ----------
+    path : str or pathlib.Path
+        Path to the VTK file.
+    backend : {"pyvista", "rust"}
+        Preferred reading backend.
+    manifold_dim : int or {"auto"}
+        Target manifold dimension.
+    point_source : {"vertices", "cell_centroids"}
+        Point-source mode.
+    include_arrays, exclude_arrays : list[str] or None
+        Data-array include/exclude filters (applied at the reader level on
+        both backends).
+    warn_on_lost_data : bool
+        Forwarded to the PyVista conversion.
+    fp32 : bool
+        If ``True``, downcast float64 arrays to float32.
+    tessellate_surface : bool
+        If ``True``, fan-tessellate mixed surface polygons (Rust path).
+    cell_data_only : bool
+        If ``True``, keep only cell data (surface meshes).
+
+    Returns
+    -------
+    Mesh
+        The converted mesh.
+    """
+    path = str(path)
+
+    if backend == "rust" and can_use_rust(path, point_source, manifold_dim):
+        try:
+            from physicsnemo_curator._lib import vtk as _rust_vtk
+
+            skip_cells = point_source == "vertices" and manifold_dim == 0
+            skip_point_data = cell_data_only or point_source == "cell_centroids"
+            rust_data = _rust_vtk.read_vtk(
+                path,
+                include_arrays=include_arrays,
+                exclude_arrays=exclude_arrays,
+                skip_cells=skip_cells,
+                skip_point_data=skip_point_data,
+            )
+            return mesh_from_rust_data(
+                rust_data,
+                manifold_dim=manifold_dim,
+                point_source=point_source,
+                fp32=fp32,
+                tessellate_surface=tessellate_surface,
+                cell_data_only=cell_data_only,
+            )
+        except Exception as exc:  # noqa: BLE001 - any Rust failure falls back to PyVista
+            logger.warning("Rust VTK reader failed for %s (%s); falling back to PyVista.", path, exc)
+
+    return mesh_from_pyvista(
+        path,
+        manifold_dim=manifold_dim,
+        point_source=point_source,
+        warn_on_lost_data=warn_on_lost_data,
+        include_arrays=include_arrays,
+        exclude_arrays=exclude_arrays,
+        fp32=fp32,
+        cell_data_only=cell_data_only,
+    )

--- a/src/physicsnemo_curator/domains/mesh/sources/drivaerml.py
+++ b/src/physicsnemo_curator/domains/mesh/sources/drivaerml.py
@@ -43,6 +43,7 @@ from physicsnemo.mesh.domain_mesh import DomainMesh
 
 from physicsnemo_curator.core.base import Param, Source
 from physicsnemo_curator.core.cache import default_data_cache_dir
+from physicsnemo_curator.domains.mesh.sources import _vtk_convert
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -556,7 +557,7 @@ class DrivAerMLSource(Source[Mesh]):
 
     @staticmethod
     def _build_cells_from_rust(rust_mesh: Any) -> torch.Tensor | None:
-        """Build a cells tensor from Rust mesh connectivity and offsets.
+        """Build a uniform cells tensor from Rust connectivity (shared core).
 
         Parameters
         ----------
@@ -566,33 +567,9 @@ class DrivAerMLSource(Source[Mesh]):
         Returns
         -------
         torch.Tensor or None
-            Cells tensor of shape ``(n_cells, nodes_per_cell)`` if
-            connectivity is available, else ``None``.
+            Uniform cell connectivity, or ``None`` for missing / mixed cells.
         """
-        connectivity = rust_mesh.cells
-        offsets = rust_mesh.cell_offsets
-
-        if connectivity is None or offsets is None or connectivity.size == 0 or offsets.size == 0:
-            return None
-
-        n_cells = rust_mesh.n_cells
-        if n_cells == 0:
-            return None
-
-        # Determine nodes per cell from offsets
-        if offsets.size > 1:
-            nodes_per_cell = int(offsets[1] - offsets[0])
-        elif connectivity.size > 0:
-            nodes_per_cell = connectivity.size // n_cells
-        else:
-            return None
-
-        # If mixed cell types, cannot form a uniform (n_cells, npc) tensor
-        if connectivity.size != n_cells * nodes_per_cell:
-            return None
-
-        cells = torch.from_numpy(connectivity.reshape(n_cells, nodes_per_cell)).to(torch.int64)
-        return cells
+        return _vtk_convert.build_cells_from_rust(rust_mesh)
 
     @staticmethod
     def _tessellate_polygons(
@@ -600,75 +577,23 @@ class DrivAerMLSource(Source[Mesh]):
         offsets: Any,
         n_cells: int,
     ) -> torch.Tensor:
-        """Fan-tessellate mixed polygons into triangles.
-
-        Converts arbitrary polygons (3–N vertices) into triangles using
-        fan triangulation from the first vertex of each polygon. A polygon
-        with *k* vertices produces *k - 2* triangles.
+        """Fan-tessellate mixed polygons into triangles (shared core).
 
         Parameters
         ----------
         connectivity : numpy.ndarray
-            Flat connectivity array (vertex indices for all cells).
+            Flat connectivity array.
         offsets : numpy.ndarray
-            Offset into *connectivity* for each cell (length ``n_cells + 1``
-            in VTK convention, or ``n_cells`` with implicit 0 start).
+            Per-cell VTK offsets.
         n_cells : int
             Number of polygons.
 
         Returns
         -------
         torch.Tensor
-            Triangle cells of shape ``(n_triangles, 3)`` with dtype int64.
+            Triangle cells of shape ``(n_triangles, 3)``.
         """
-        import numpy as np
-
-        conn = np.asarray(connectivity, dtype=np.int64)
-        offs = np.asarray(offsets, dtype=np.int64)
-
-        # VTK offsets: [end0, end1, ...] (cumulative, 1-based)
-        # Convert to start/end pairs
-        if offs.size == n_cells:
-            # Offsets give the *end* of each cell's connectivity
-            starts = np.empty(n_cells, dtype=np.int64)
-            starts[0] = 0
-            starts[1:] = offs[:-1]
-            ends = offs
-        else:
-            # Offset array has n_cells+1 entries: [0, end0, end1, ...]
-            starts = offs[:-1]
-            ends = offs[1:]
-
-        # Count vertices per cell and total triangles
-        n_verts = ends - starts  # vertices per polygon
-        n_tris_per_cell = n_verts - 2  # triangles per polygon
-        total_tris = int(n_tris_per_cell.sum())
-
-        # Vectorized fan triangulation:
-        # For each polygon, fan from vertex 0: tri_j = (v0, v_{j}, v_{j+1})
-        # Build index arrays for all triangles simultaneously.
-
-        # Repeat the start offset for each triangle from that polygon
-        # cell_of_tri[t] = which polygon triangle t belongs to
-        cell_of_tri = np.repeat(np.arange(n_cells, dtype=np.int64), n_tris_per_cell)
-
-        # local_j[t] = which fan triangle within the polygon (0-based)
-        # For polygon with k verts -> tris 0..k-3, local_j = 0,1,...,k-3
-        local_j = np.arange(total_tris, dtype=np.int64)
-        # Subtract cumulative tris-per-cell to get local index
-        cum_tris = np.zeros(n_cells + 1, dtype=np.int64)
-        np.cumsum(n_tris_per_cell, out=cum_tris[1:])
-        local_j -= cum_tris[cell_of_tri]
-
-        # Start of each polygon's connectivity
-        poly_starts = starts[cell_of_tri]
-
-        triangles = np.empty((total_tris, 3), dtype=np.int64)
-        triangles[:, 0] = conn[poly_starts]  # fan center (vertex 0)
-        triangles[:, 1] = conn[poly_starts + local_j + 1]
-        triangles[:, 2] = conn[poly_starts + local_j + 2]
-
-        return torch.from_numpy(triangles)
+        return _vtk_convert.tessellate_polygons(connectivity, offsets, n_cells)
 
     @staticmethod
     def _expand_cell_data_for_tessellation(
@@ -676,17 +601,14 @@ class DrivAerMLSource(Source[Mesh]):
         offsets: Any,
         n_cells: int,
     ) -> dict[str, torch.Tensor]:
-        """Repeat cell data entries for tessellated triangles.
-
-        When a polygon with *k* vertices is split into *k - 2* triangles,
-        the cell data value must be repeated *k - 2* times.
+        """Repeat cell data for tessellated triangles (shared core).
 
         Parameters
         ----------
         cell_data_dict : dict
-            Mapping of field name to tensor of shape ``(n_cells, ...)``.
+            Mapping of field name to ``(n_cells, ...)`` tensor.
         offsets : numpy.ndarray
-            Cell offsets (same convention as ``_tessellate_polygons``).
+            Cell offsets.
         n_cells : int
             Number of original polygons.
 
@@ -695,30 +617,7 @@ class DrivAerMLSource(Source[Mesh]):
         dict
             Expanded cell data with shape ``(n_triangles, ...)``.
         """
-        import numpy as np
-
-        offs = np.asarray(offsets, dtype=np.int64)
-
-        if offs.size == n_cells:
-            starts = np.empty(n_cells, dtype=np.int64)
-            starts[0] = 0
-            starts[1:] = offs[:-1]
-            ends = offs
-        else:
-            starts = offs[:-1]
-            ends = offs[1:]
-
-        n_verts = ends - starts
-        n_tris_per_cell = (n_verts - 2).astype(np.int64)
-
-        # Build repeat indices: each cell i is repeated n_tris_per_cell[i] times
-        repeat_counts = torch.from_numpy(n_tris_per_cell)
-
-        expanded = {}
-        for name, tensor in cell_data_dict.items():
-            expanded[name] = torch.repeat_interleave(tensor, repeat_counts, dim=0)
-
-        return expanded
+        return _vtk_convert.expand_cell_data_for_tessellation(cell_data_dict, offsets, n_cells)
 
     # -- Volume reading -------------------------------------------------------
 
@@ -1138,48 +1037,11 @@ class DrivAerMLSource(Source[Mesh]):
         n_cells = rust_mesh.n_cells  # ty: ignore[unresolved-attribute]
         connectivity = rust_mesh.cells  # ty: ignore[unresolved-attribute]
 
-        points_raw = torch.from_numpy(rust_mesh.points)  # ty: ignore[unresolved-attribute]
-        offsets = rust_mesh.cell_offsets  # ty: ignore[unresolved-attribute]
-
-        if (
-            connectivity is not None
-            and connectivity.size > 0
-            and offsets is not None
-            and offsets.size > 1
-            and n_cells > 0
-        ):
-            import numpy as np
-
-            # Offsets are cumulative node counts: cell i spans
-            # connectivity[starts[i]:starts[i+1]].
-            off = np.empty(n_cells + 1, dtype=np.int64)
-            off[0] = 0
-            off[1:] = offsets
-
-            # Check if all cells have the same node count (uniform mesh)
-            nodes_first = int(off[1])
-            if connectivity.size == n_cells * nodes_first:
-                # Uniform cell type — fast vectorized path
-                conn = torch.from_numpy(connectivity.reshape(n_cells, nodes_first)).to(torch.int64)
-                cell_points = points_raw[conn]  # (n_cells, nodes_per_cell, 3)
-                centroids = cell_points.mean(dim=1)  # (n_cells, 3)
-            else:
-                # Mixed cell types — vectorized scatter-add approach
-                conn_t = torch.from_numpy(connectivity).to(torch.int64)
-                # Gather all referenced points
-                all_pts = points_raw[conn_t]  # (total_nodes, 3)
-                # Build cell index for each node in connectivity
-                nodes_per_cell = np.diff(off)  # (n_cells,)
-                cell_ids = np.repeat(np.arange(n_cells, dtype=np.int64), nodes_per_cell)
-                cell_ids_t = torch.from_numpy(cell_ids).unsqueeze(1).expand(-1, 3)
-                # Sum points per cell
-                centroids = torch.zeros(n_cells, 3, dtype=points_raw.dtype)
-                centroids.scatter_add_(0, cell_ids_t, all_pts)
-                # Divide by node count per cell
-                npc_t = torch.from_numpy(nodes_per_cell.astype(np.float64)).to(points_raw.dtype)
-                centroids /= npc_t.unsqueeze(1)
+        if connectivity is not None and connectivity.size > 0 and n_cells > 0:
+            # Shared core: uniform fast path + mixed scatter-add.
+            centroids = _vtk_convert.compute_centroids_from_rust(rust_mesh)
         else:
-            centroids = points_raw
+            centroids = torch.from_numpy(rust_mesh.points)  # ty: ignore[unresolved-attribute]
 
         # Cell data becomes point_data for the centroid point-cloud
         # Filter to target interior fields only
@@ -1461,7 +1323,7 @@ class DrivAerMLSource(Source[Mesh]):
 
     @staticmethod
     def _downcast_fp32(mesh: Mesh) -> Mesh:
-        """Downcast float64 tensors in a Mesh to float32 in-place.
+        """Downcast float64 tensors in a Mesh to float32 in-place (shared core).
 
         Parameters
         ----------
@@ -1473,22 +1335,7 @@ class DrivAerMLSource(Source[Mesh]):
         Mesh
             The same mesh with float64 arrays converted to float32.
         """
-        if mesh.points.dtype == torch.float64:
-            mesh.points = mesh.points.float()
-
-        if mesh.point_data is not None:
-            for key in list(mesh.point_data.keys()):  # noqa: SIM118 - TensorDict needs .keys()
-                tensor = mesh.point_data[key]
-                if tensor.dtype == torch.float64:
-                    mesh.point_data[key] = tensor.float()
-
-        if mesh.cell_data is not None:
-            for key in list(mesh.cell_data.keys()):  # noqa: SIM118 - TensorDict needs .keys()
-                tensor = mesh.cell_data[key]
-                if tensor.dtype == torch.float64:
-                    mesh.cell_data[key] = tensor.float()
-
-        return mesh
+        return _vtk_convert.downcast_fp32(mesh)
 
     @staticmethod
     def _merge_to_single_solid(pv_mesh: Any) -> Any:

--- a/src/physicsnemo_curator/domains/mesh/sources/vti.py
+++ b/src/physicsnemo_curator/domains/mesh/sources/vti.py
@@ -1,0 +1,244 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Structured-grid (VTK ImageData / ``.vti``) source for mesh pipelines.
+
+VTK ImageData describes a uniform rectilinear grid that is fully determined
+by ``origin``, ``spacing``, and ``dimensions`` — there is no explicit point
+list or connectivity.  Forcing such data through the unstructured
+:class:`physicsnemo.mesh.Mesh` model would materialise redundant coordinates
+and discard the regular lattice that grid models (CNN/U-Net/FNO) rely on.
+
+Instead, this source reads each ``.vti`` file into a
+:class:`tensordict.TensorDict` of **dense N-D field tensors**:
+
+* ``point_data`` — a sub-TensorDict with ``batch_size = [Nz, Ny, Nx]``; each
+  scalar field has shape ``(Nz, Ny, Nx)`` and each vector field
+  ``(Nz, Ny, Nx, C)`` (VTK x-fastest ordering).
+* ``cell_data`` — a sub-TensorDict with ``batch_size = [Cz, Cy, Cx]`` where
+  ``Ci = max(dim_i - 1, 1)``.
+* ``grid`` — a non-batched sub-TensorDict carrying ``origin`` (3,),
+  ``spacing`` (3,), ``dimensions`` (3,, point counts), and ``direction``
+  (3, 3).
+
+The result is written as a tensordict memmap **sidecar** beside the mesh
+outputs via
+:class:`~physicsnemo_curator.domains.mesh.sinks.grid_sidecar.GridSidecarSink`.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from typing import TYPE_CHECKING, Any, ClassVar
+
+import numpy as np
+import torch
+from tensordict import TensorDict
+
+from physicsnemo_curator.core.base import Param, Source
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+#: File extension recognised as VTK ImageData.
+_VTI_EXTENSIONS: frozenset[str] = frozenset({".vti"})
+
+
+def _reshape_field(arr: np.ndarray, grid_shape: tuple[int, int, int]) -> torch.Tensor:
+    """Reshape a flat VTK field array into a dense ``(Nz, Ny, Nx[, C])`` tensor.
+
+    VTK stores ImageData with the x index varying fastest, then y, then z, so
+    a C-order reshape into ``(Nz, Ny, Nx)`` recovers ``[z, y, x]`` indexing.
+
+    Parameters
+    ----------
+    arr : numpy.ndarray
+        Flat field array of shape ``(N,)`` (scalar) or ``(N, C)`` (vector).
+    grid_shape : tuple[int, int, int]
+        ``(Nz, Ny, Nx)`` target grid shape.
+
+    Returns
+    -------
+    torch.Tensor
+        Dense tensor of shape ``(Nz, Ny, Nx)`` or ``(Nz, Ny, Nx, C)``.
+    """
+    arr = np.ascontiguousarray(arr)
+    nz, ny, nx = grid_shape
+    reshaped = arr.reshape(nz, ny, nx) if arr.ndim == 1 else arr.reshape(nz, ny, nx, arr.shape[1])
+    return torch.from_numpy(np.ascontiguousarray(reshaped))
+
+
+def imagedata_to_griddict(image: Any, *, fp32: bool = False) -> TensorDict:
+    """Convert a PyVista ImageData object to a structured-grid TensorDict.
+
+    Parameters
+    ----------
+    image : pyvista.ImageData
+        The loaded ImageData (uniform grid).
+    fp32 : bool
+        If ``True``, downcast float64 field/geometry arrays to float32.
+
+    Returns
+    -------
+    TensorDict
+        A scalar-batch TensorDict with ``grid`` metadata and (when present)
+        ``point_data`` / ``cell_data`` sub-TensorDicts of dense field
+        tensors.
+    """
+    nx, ny, nz = (int(d) for d in image.dimensions)
+    point_shape = (nz, ny, nx)
+    cell_shape = (max(nz - 1, 1), max(ny - 1, 1), max(nx - 1, 1))
+
+    float_dtype = torch.float32 if fp32 else torch.float64
+
+    def _maybe_cast(t: torch.Tensor) -> torch.Tensor:
+        if fp32 and t.dtype == torch.float64:
+            return t.float()
+        return t
+
+    point_fields: dict[str, torch.Tensor] = {}
+    for name in image.point_data:
+        point_fields[str(name)] = _maybe_cast(_reshape_field(np.asarray(image.point_data[name]), point_shape))
+
+    cell_fields: dict[str, torch.Tensor] = {}
+    for name in image.cell_data:
+        cell_fields[str(name)] = _maybe_cast(_reshape_field(np.asarray(image.cell_data[name]), cell_shape))
+
+    direction = getattr(image, "direction_matrix", None)
+    if direction is None:
+        direction_t = torch.eye(3, dtype=float_dtype)
+    else:
+        direction_t = torch.as_tensor(np.asarray(direction).reshape(3, 3), dtype=float_dtype)
+
+    grid_meta = TensorDict(
+        {
+            "origin": torch.as_tensor(np.asarray(image.origin), dtype=float_dtype),
+            "spacing": torch.as_tensor(np.asarray(image.spacing), dtype=float_dtype),
+            "dimensions": torch.tensor([nx, ny, nz], dtype=torch.int64),
+            "direction": direction_t,
+        },
+        batch_size=[],
+    )
+
+    contents: dict[str, TensorDict] = {"grid": grid_meta}
+    if point_fields:
+        contents["point_data"] = TensorDict(point_fields, batch_size=list(point_shape))
+    if cell_fields:
+        contents["cell_data"] = TensorDict(cell_fields, batch_size=list(cell_shape))
+
+    return TensorDict(contents, batch_size=[])
+
+
+class VTISource(Source[TensorDict]):
+    """Read local VTK ImageData (``.vti``) files as structured-grid TensorDicts.
+
+    Each discovered ``.vti`` file is converted (via
+    :func:`imagedata_to_griddict`) into a :class:`tensordict.TensorDict` of
+    dense N-D field tensors plus grid metadata, suitable for memmap storage
+    as a sidecar alongside mesh outputs.
+
+    Parameters
+    ----------
+    input_path : str
+        Path to a local directory containing ``.vti`` files, or a single
+        ``.vti`` file.
+    file_pattern : str
+        Glob pattern for filtering files inside a directory.  Defaults to
+        ``"**/*"`` (recursive).
+    fp32 : bool
+        If ``True``, downcast float64 arrays to float32.
+
+    Examples
+    --------
+    >>> source = VTISource("./grids/")  # doctest: +SKIP
+    >>> grid = next(source[0])  # doctest: +SKIP
+    >>> grid["point_data"].batch_size  # doctest: +SKIP
+    torch.Size([64, 64, 64])
+    """
+
+    name: ClassVar[str] = "VTI Reader"
+    description: ClassVar[str] = "Read VTK ImageData (.vti) as dense structured-grid TensorDicts"
+
+    @classmethod
+    def params(cls) -> list[Param]:
+        """Return parameter descriptors for the VTI source.
+
+        Returns
+        -------
+        list[Param]
+            The ``input_path``, ``file_pattern``, and ``fp32`` parameters.
+        """
+        return [
+            Param(name="input_path", description="Path to .vti file or directory (local)", type=str),
+            Param(name="file_pattern", description="Glob pattern for filtering files", type=str, default="**/*"),
+            Param(name="fp32", description="Downcast float64 arrays to float32", type=bool, default=False),
+        ]
+
+    def __init__(self, input_path: str, file_pattern: str = "**/*", *, fp32: bool = False) -> None:
+        self._fp32 = fp32
+
+        root = pathlib.Path(input_path)
+        if root.is_file():
+            if root.suffix.lower() not in _VTI_EXTENSIONS:
+                msg = f"File {root} does not have a recognised VTI extension {sorted(_VTI_EXTENSIONS)}."
+                raise ValueError(msg)
+            self._root = root.parent
+            self._files: list[pathlib.Path] = [root.resolve()]
+            return
+
+        if not root.is_dir():
+            msg = f"Path {root} is not a file or directory."
+            raise FileNotFoundError(msg)
+
+        self._root = root.resolve()
+        discovered = sorted(
+            p.resolve() for p in root.glob(file_pattern) if p.is_file() and p.suffix.lower() in _VTI_EXTENSIONS
+        )
+        if not discovered:
+            msg = f"No .vti files found in {root} with pattern {file_pattern!r}."
+            raise ValueError(msg)
+        self._files = discovered
+
+    def __len__(self) -> int:
+        """Return the number of discovered ``.vti`` files."""
+        return len(self._files)
+
+    def __getitem__(self, index: int) -> Generator[TensorDict]:
+        """Read the *index*-th ``.vti`` file and yield a structured-grid TensorDict.
+
+        Parameters
+        ----------
+        index : int
+            Zero-based file index.
+
+        Yields
+        ------
+        TensorDict
+            The converted structured-grid TensorDict.
+        """
+        import pyvista as pv
+
+        image = pv.read(str(self._files[index]))
+        yield imagedata_to_griddict(image, fp32=self._fp32)
+
+    @property
+    def root(self) -> pathlib.Path:
+        """Return the root directory of this source."""
+        return self._root
+
+    def relative_path(self, index: int) -> str:
+        """Return the *index*-th file path relative to the root (POSIX style)."""
+        return self._files[index].relative_to(self._root).as_posix()

--- a/src/physicsnemo_curator/domains/mesh/sources/vtk.py
+++ b/src/physicsnemo_curator/domains/mesh/sources/vtk.py
@@ -369,7 +369,7 @@ class VTKSource(Source[Mesh]):
 
         from physicsnemo.mesh.domain_mesh import DomainMesh
 
-        _, volume_path, boundary_path = item
+        _, volume_path, boundary_path = item  # ty: ignore[invalid-assignment]
         interior = self._read_one(volume_path)
         boundary = self._read_one(boundary_path)
         domain = DomainMesh(interior=interior, boundaries={self._boundary_name: boundary})

--- a/src/physicsnemo_curator/domains/mesh/sources/vtk.py
+++ b/src/physicsnemo_curator/domains/mesh/sources/vtk.py
@@ -16,37 +16,59 @@
 
 """VTK file source for mesh pipelines.
 
-Reads VTK-format files (``.vtk``, ``.vtp``, ``.vtu``, ``.vts``, ``.vtm``)
-from a local directory and converts each to a
-:class:`physicsnemo.mesh.Mesh` using :func:`physicsnemo.mesh.io.from_pyvista`.
+Reads VTK-format files (``.vtk``, ``.vtp``, ``.vtu``, ``.vts``, ``.vtm``,
+``.stl``) from a local directory and converts each to a
+:class:`physicsnemo.mesh.Mesh` (or, in *domain-mesh mode*, a
+:class:`physicsnemo.mesh.domain_mesh.DomainMesh`).
 
 File discovery uses :func:`pathlib.Path.glob` with an optional pattern,
-filtering to recognised VTK extensions.
+filtering to recognised extensions.
 
 The conversion supports multiple manifold dimensions (point clouds, lines,
-surfaces, volumes) and two point-source modes (vertices or cell centroids).
-See :func:`physicsnemo.mesh.io.from_pyvista` for full details.
+surfaces, volumes) and two point-source modes (vertices or cell centroids),
+each resolvable **per file** via path-glob rules.  Data arrays can be
+filtered at the VTK reader level (include/exclude keyed by path glob) so
+unwanted fields are never materialised.  Reading is delegated to the shared
+conversion core in
+:mod:`physicsnemo_curator.domains.mesh.sources._vtk_convert`, which supports
+both PyVista and a fast native Rust backend.
 """
 
 from __future__ import annotations
 
+import fnmatch
 import pathlib
-from typing import TYPE_CHECKING, ClassVar, Literal
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
-import pyvista as pv
 from physicsnemo.mesh import Mesh
-from physicsnemo.mesh.io import from_pyvista
 
 from physicsnemo_curator.core.base import Param, Source
+from physicsnemo_curator.domains.mesh.sources._key_filter import (
+    resolve_arrays,
+    resolve_path_value,
+    rules_from_config,
+)
+from physicsnemo_curator.domains.mesh.sources._vtk_convert import Backend, read_vtk_mesh
 
 if TYPE_CHECKING:
     from collections.abc import Generator
 
-#: File extensions recognised as VTK formats.
-_VTK_EXTENSIONS: frozenset[str] = frozenset({".vtk", ".vtp", ".vtu", ".vts", ".vtm"})
+    from physicsnemo.mesh.domain_mesh import DomainMesh
 
-#: Valid backend options for VTK reading.
-Backend = Literal["pyvista", "rust"]
+#: File extensions recognised as VTK formats.
+_VTK_EXTENSIONS: frozenset[str] = frozenset({".vtk", ".vtp", ".vtu", ".vts", ".vtm", ".stl"})
+
+
+def _coerce_manifold_dim(value: Any) -> int | Literal["auto"]:
+    """Normalise a manifold-dim setting to ``int`` or ``"auto"``."""
+    if value is None:
+        return "auto"
+    if isinstance(value, int):
+        return value
+    s = str(value).strip().lower()
+    if s in ("auto", "", "none", "null"):
+        return "auto"
+    return int(s)
 
 
 class VTKSource(Source[Mesh]):
@@ -67,33 +89,53 @@ class VTKSource(Source[Mesh]):
         ``"**/*"`` which recursively discovers all VTK files.  Use ``"*"``
         for flat (non-recursive) discovery, or a custom pattern such as
         ``"timestep_*"`` for selective matching.
-    manifold_dim : int or {"auto"}
-        Target manifold dimension passed to ``from_pyvista``:
+    manifold_dim : int, {"auto"}, or list[dict]
+        Target manifold dimension passed to the conversion:
 
         - ``"auto"`` (default): detect from cell types.
         - ``0``: point cloud (vertices only, no cells).
         - ``1``: line mesh (edge cells).
         - ``2``: surface mesh (triangulated).
         - ``3``: volume mesh (tetrahedralized).
-    point_source : {"vertices", "cell_centroids"}
-        Controls what becomes the Mesh points:
+
+        May also be a list of ``{"pattern": glob, "value": ...}`` rules to
+        select the dimension **per file** (longest matching pattern wins),
+        mirroring per-file-type defaults (e.g. ``volume_*.vtu`` -> 0).
+    point_source : {"vertices", "cell_centroids"} or list[dict]
+        Controls what becomes the Mesh points (scalar or per-path rules):
 
         - ``"vertices"`` (default): mesh vertices become points,
           ``point_data`` is preserved.
         - ``"cell_centroids"``: cell centroids become points,
-          ``cell_data`` is mapped to ``point_data``.  Only
-          ``manifold_dim`` 0 and 1 are valid in this mode.
+          ``cell_data`` is mapped to ``point_data``.
     warn_on_lost_data : bool
-        If *True* (default), emit a warning when the conversion discards
-        non-empty data arrays (e.g. cell data lost during dimension
-        reduction).
+        If *True* (default), emit a warning when the PyVista conversion
+        discards non-empty data arrays.
     backend : {"pyvista", "rust"}
         VTK reading backend:
 
-        - ``"pyvista"`` (default): use PyVista for full-featured reading.
-        - ``"rust"``: use the native Rust backend for faster reading.
-          Note: The Rust backend only supports ASCII VTU/VTP files and
-          does not support ``manifold_dim`` or ``point_source`` options.
+        - ``"pyvista"`` (default): full-featured reading.
+        - ``"rust"``: native Rust backend for faster reading of VTU/VTP;
+          transparently falls back to PyVista when unsupported.
+    key_filters : list[dict] or None
+        Per-path data-array filter rules.  Each dict has ``path_pattern``,
+        ``mode`` (``"include"`` / ``"exclude"``), and ``keys``.  Applied at
+        the reader level so dropped arrays are never materialised.
+    volume_pattern : str or None
+        Filename glob identifying volume files for *domain-mesh mode*.
+    boundary_pattern : str or None
+        Filename glob identifying boundary files for *domain-mesh mode*.
+        When both *volume_pattern* and *boundary_pattern* are set, files are
+        paired by parent directory into a
+        :class:`~physicsnemo.mesh.domain_mesh.DomainMesh` per index;
+        unpaired files fall back to standalone :class:`Mesh`.
+    boundary_name : str
+        Key under which the paired boundary mesh is stored in the
+        ``DomainMesh`` (default ``"vehicle"``).
+    boundary_generator : object or None
+        Optional boundary-condition generator applied to each assembled
+        ``DomainMesh`` (domain-mesh mode).  See
+        :mod:`physicsnemo_curator.domains.mesh.boundaries`.
 
     Examples
     --------
@@ -104,13 +146,15 @@ class VTKSource(Source[Mesh]):
     42
     >>> mesh = next(source[0])
 
-    Custom glob pattern:
+    Domain-mesh mode (volume + boundary -> DomainMesh):
 
-    >>> source = VTKSource("./data/", file_pattern="timestep_*")
-
-    Using the fast Rust backend:
-
-    >>> source = VTKSource("./cfd_results/", backend="rust")
+    >>> source = VTKSource(  # doctest: +SKIP
+    ...     "./dataset/",
+    ...     volume_pattern="volume_*.vtu",
+    ...     boundary_pattern="boundary_*.vtp",
+    ...     manifold_dim=[{"pattern": "**/volume_*", "value": 0}],
+    ...     point_source=[{"pattern": "**/volume_*", "value": "cell_centroids"}],
+    ... )
 
     Note
     ----
@@ -119,7 +163,9 @@ class VTKSource(Source[Mesh]):
     """
 
     name: ClassVar[str] = "VTK Reader"
-    description: ClassVar[str] = "Read VTK files (.vtk, .vtp, .vtu, .vts, .vtm) and convert to physicsnemo Mesh"
+    description: ClassVar[str] = (
+        "Read VTK files (.vtk, .vtp, .vtu, .vts, .vtm, .stl) and convert to physicsnemo Mesh / DomainMesh"
+    )
 
     @classmethod
     def params(cls) -> list[Param]:
@@ -128,22 +174,22 @@ class VTKSource(Source[Mesh]):
         Returns
         -------
         list[Param]
-            Parameter list including file path, glob pattern, and
-            ``from_pyvista`` conversion options.
+            Parameter list including file path, glob pattern, conversion
+            options, array filters, and domain-mesh pairing patterns.
         """
         return [
             Param(name="input_path", description="Path to VTK file or directory (local)", type=str),
             Param(name="file_pattern", description="Glob pattern for filtering files", type=str, default="**/*"),
             Param(
                 name="manifold_dim",
-                description="Target manifold dimension (auto, 0, 1, 2, 3)",
+                description="Target manifold dimension (auto, 0, 1, 2, 3), or per-path rule list",
                 type=str,
                 default="auto",
                 choices=["auto", "0", "1", "2", "3"],
             ),
             Param(
                 name="point_source",
-                description="Point source mode: vertices or cell_centroids",
+                description="Point source mode: vertices or cell_centroids (or per-path rule list)",
                 type=str,
                 default="vertices",
                 choices=["vertices", "cell_centroids"],
@@ -161,6 +207,30 @@ class VTKSource(Source[Mesh]):
                 default="pyvista",
                 choices=["pyvista", "rust"],
             ),
+            Param(
+                name="key_filters",
+                description="Per-path data-array filter rules (path_pattern, mode, keys)",
+                type=list,
+                default=None,
+            ),
+            Param(
+                name="volume_pattern",
+                description="Filename glob for volume files (enables domain-mesh mode with boundary_pattern)",
+                type=str,
+                default=None,
+            ),
+            Param(
+                name="boundary_pattern",
+                description="Filename glob for boundary files (enables domain-mesh mode with volume_pattern)",
+                type=str,
+                default=None,
+            ),
+            Param(
+                name="boundary_name",
+                description="Boundary key for the paired DomainMesh boundary",
+                type=str,
+                default="vehicle",
+            ),
         ]
 
     def __init__(
@@ -168,15 +238,25 @@ class VTKSource(Source[Mesh]):
         input_path: str,
         file_pattern: str = "**/*",
         *,
-        manifold_dim: int | Literal["auto"] = "auto",
-        point_source: Literal["vertices", "cell_centroids"] = "vertices",
+        manifold_dim: int | Literal["auto"] | list[dict] = "auto",
+        point_source: Literal["vertices", "cell_centroids"] | list[dict] = "vertices",
         warn_on_lost_data: bool = True,
         backend: Backend = "pyvista",
+        key_filters: list[dict] | None = None,
+        volume_pattern: str | None = None,
+        boundary_pattern: str | None = None,
+        boundary_name: str = "vehicle",
+        boundary_generator: Any = None,
     ) -> None:
         self._manifold_dim = manifold_dim
         self._point_source = point_source
         self._warn_on_lost_data = warn_on_lost_data
         self._backend: Backend = backend
+        self._key_filters = rules_from_config(key_filters)
+        self._volume_pattern = volume_pattern
+        self._boundary_pattern = boundary_pattern
+        self._boundary_name = boundary_name
+        self._boundary_generator = boundary_generator
 
         root = pathlib.Path(input_path)
 
@@ -186,55 +266,149 @@ class VTKSource(Source[Mesh]):
                 msg = f"File {root} does not have a recognised VTK extension {sorted(_VTK_EXTENSIONS)}."
                 raise ValueError(msg)
             self._root = root.parent
-            self._files: list[pathlib.Path] = [root.resolve()]
-            return
-
-        if not root.is_dir():
+            discovered: list[pathlib.Path] = [root.resolve()]
+        elif root.is_dir():
+            self._root = root.resolve()
+            discovered = sorted(
+                p.resolve() for p in root.glob(file_pattern) if p.is_file() and p.suffix.lower() in _VTK_EXTENSIONS
+            )
+            if not discovered:
+                msg = (
+                    f"No VTK files found in {root} with pattern {file_pattern!r}; "
+                    f"expected extensions {sorted(_VTK_EXTENSIONS)}."
+                )
+                raise ValueError(msg)
+        else:
             msg = f"Path {root} is not a file or directory."
             raise FileNotFoundError(msg)
 
-        self._root = root.resolve()
+        # Build work items: ("single", file) or ("pair", volume, boundary).
+        self._pairing = volume_pattern is not None and boundary_pattern is not None
+        if self._pairing:
+            self._items = self._discover_pairs(discovered, volume_pattern, boundary_pattern)
+        else:
+            self._items = [("single", f) for f in discovered]
 
-        # Glob and filter to VTK extensions, then sort for deterministic order
-        discovered = sorted(
-            p.resolve() for p in root.glob(file_pattern) if p.is_file() and p.suffix.lower() in _VTK_EXTENSIONS
-        )
-        if not discovered:
-            msg = (
-                f"No VTK files found in {root} with pattern {file_pattern!r}; "
-                f"expected extensions {sorted(_VTK_EXTENSIONS)}."
-            )
-            raise ValueError(msg)
+        # Representative path per item (for naming / relative_path).
+        self._files: list[pathlib.Path] = [item[1] for item in self._items]
 
-        self._files = discovered
+    @staticmethod
+    def _discover_pairs(
+        files: list[pathlib.Path],
+        volume_pattern: str,
+        boundary_pattern: str,
+    ) -> list[tuple[str, pathlib.Path, pathlib.Path] | tuple[str, pathlib.Path]]:
+        """Pair volume + boundary files by parent directory.
+
+        Files matching *volume_pattern* / *boundary_pattern* (by filename)
+        are paired one-per-directory; everything else becomes a standalone
+        item.
+
+        Returns
+        -------
+        list
+            Work items: ``("pair", volume, boundary)`` or ``("single", file)``,
+            ordered with pairs first (by directory) then unpaired files.
+        """
+        volumes: dict[pathlib.Path, pathlib.Path] = {}
+        boundaries: dict[pathlib.Path, pathlib.Path] = {}
+        other: list[pathlib.Path] = []
+
+        for f in files:
+            if fnmatch.fnmatch(f.name, volume_pattern):
+                volumes[f.parent] = f
+            elif fnmatch.fnmatch(f.name, boundary_pattern):
+                boundaries[f.parent] = f
+            else:
+                other.append(f)
+
+        items: list[tuple] = []
+        for parent in sorted(volumes):
+            vol = volumes[parent]
+            bnd = boundaries.pop(parent, None)
+            if bnd is not None:
+                items.append(("pair", vol, bnd))
+            else:
+                other.append(vol)
+        # Boundaries with no matching volume become standalone too.
+        other.extend(boundaries.values())
+
+        for f in sorted(other):
+            items.append(("single", f))
+        return items
 
     # -- Source interface -----------------------------------------------------
 
     def __len__(self) -> int:
-        """Return the number of discovered VTK files."""
-        return len(self._files)
+        """Return the number of discovered items (files or volume/boundary pairs)."""
+        return len(self._items)
 
-    def __getitem__(self, index: int) -> Generator[Mesh]:
-        """Read the *index*-th VTK file and yield a Mesh.
+    def __getitem__(self, index: int) -> Generator[Mesh | DomainMesh]:
+        """Read the *index*-th item and yield a Mesh or DomainMesh.
 
-        The file is loaded with the configured backend and converted to
-        a :class:`~physicsnemo.mesh.Mesh`. When using the PyVista backend,
-        the mesh is converted via :func:`physicsnemo.mesh.io.from_pyvista`
-        using the conversion parameters supplied at construction time.
+        For standalone items a single :class:`~physicsnemo.mesh.Mesh` is
+        yielded.  In domain-mesh mode, a volume/boundary pair is assembled
+        into a :class:`~physicsnemo.mesh.domain_mesh.DomainMesh` (and the
+        optional ``boundary_generator`` is applied).
 
         Parameters
         ----------
         index : int
-            Zero-based file index into the discovered VTK file list.
+            Zero-based index into the discovered item list.
 
         Yields
         ------
-        Mesh
-            The converted physicsnemo Mesh.
+        Mesh or DomainMesh
+            The converted physicsnemo object.
         """
-        path = str(self._files[index])
-        mesh = self._read_with_rust(path) if self._backend == "rust" else self._read_with_pyvista(path)
-        yield mesh
+        item = self._items[index]
+
+        if item[0] == "single":
+            yield self._read_one(item[1])
+            return
+
+        from physicsnemo.mesh.domain_mesh import DomainMesh
+
+        _, volume_path, boundary_path = item
+        interior = self._read_one(volume_path)
+        boundary = self._read_one(boundary_path)
+        domain = DomainMesh(interior=interior, boundaries={self._boundary_name: boundary})
+
+        if self._boundary_generator is not None:
+            from physicsnemo_curator.domains.mesh.boundaries import inject_boundaries
+
+            domain = inject_boundaries(domain, self._boundary_generator)
+
+        yield domain
+
+    def _read_one(self, path: pathlib.Path) -> Mesh:
+        """Read one VTK file into a Mesh using per-path conversion settings.
+
+        Parameters
+        ----------
+        path : pathlib.Path
+            Path to the VTK file.
+
+        Returns
+        -------
+        Mesh
+            The converted mesh.
+        """
+        path_str = str(path)
+        manifold_dim = _coerce_manifold_dim(resolve_path_value(self._manifold_dim, path_str, default="auto"))
+        point_source = resolve_path_value(self._point_source, path_str, default="vertices")
+        include_arrays, exclude_arrays = resolve_arrays(path_str, self._key_filters)
+
+        return read_vtk_mesh(
+            path_str,
+            backend=self._backend,
+            manifold_dim=manifold_dim,
+            point_source=point_source,
+            include_arrays=include_arrays,
+            exclude_arrays=exclude_arrays,
+            warn_on_lost_data=self._warn_on_lost_data,
+            tessellate_surface=(manifold_dim == 2),
+        )
 
     # -- Path helpers (used by MeshSink for naming) --------------------------
 
@@ -250,16 +424,17 @@ class VTKSource(Source[Mesh]):
         return self._root
 
     def relative_path(self, index: int) -> str:
-        """Return the path of the *index*-th file relative to the root.
+        """Return the representative path of the *index*-th item relative to the root.
 
-        This is used by sinks (e.g.
-        :class:`~physicsnemo_curator.domains.mesh.sinks.mesh_writer.MeshSink`) to
-        resolve ``{relpath}`` and ``{stem}`` naming placeholders.
+        For standalone items this is the file itself; for volume/boundary
+        pairs it is the volume file.  Used by sinks (e.g.
+        :class:`~physicsnemo_curator.domains.mesh.sinks.mesh_writer.MeshSink`)
+        to resolve ``{relpath}`` and ``{stem}`` naming placeholders.
 
         Parameters
         ----------
         index : int
-            Zero-based file index.
+            Zero-based item index.
 
         Returns
         -------
@@ -267,67 +442,3 @@ class VTKSource(Source[Mesh]):
             POSIX-style relative path (e.g. ``"subdir/mesh.vtu"``).
         """
         return self._files[index].relative_to(self._root).as_posix()
-
-    # -- Private readers -----------------------------------------------------
-
-    def _read_with_pyvista(self, path: str) -> Mesh:
-        """Read VTK file using PyVista backend.
-
-        Parameters
-        ----------
-        path : str
-            Path to the VTK file.
-
-        Returns
-        -------
-        Mesh
-            Converted physicsnemo Mesh.
-        """
-        pv_mesh = pv.read(path)
-        return from_pyvista(
-            pv_mesh,
-            manifold_dim=self._manifold_dim,
-            point_source=self._point_source,
-            warn_on_lost_data=self._warn_on_lost_data,
-        )
-
-    def _read_with_rust(self, path: str) -> Mesh:
-        """Read VTK file using Rust backend.
-
-        The Rust backend returns raw mesh data without the from_pyvista
-        conversion. Currently only supports ASCII VTU/VTP files and does
-        not support manifold_dim or point_source options.
-
-        Parameters
-        ----------
-        path : str
-            Path to the VTK file.
-
-        Returns
-        -------
-        Mesh
-            Raw mesh with points and point_data from the VTK file.
-        """
-        import torch
-        from tensordict import TensorDict
-
-        from physicsnemo_curator._lib import vtk
-
-        rust_mesh = vtk.read_vtk(path)
-
-        # Convert Rust mesh to physicsnemo Mesh
-        points = torch.from_numpy(rust_mesh.points)
-
-        # Build point_data TensorDict from Rust arrays
-        point_data_dict = {}
-        for name, data in rust_mesh.point_data.items():
-            arr = torch.from_numpy(data)
-            point_data_dict[name] = arr
-
-        point_data = TensorDict(point_data_dict, batch_size=[rust_mesh.n_points]) if point_data_dict else None
-
-        return Mesh(
-            points=points,
-            point_data=point_data,
-            # Note: cells/faces not converted - Rust backend is for raw data access
-        )

--- a/test/domains/mesh/test_ns_cylinder.py
+++ b/test/domains/mesh/test_ns_cylinder.py
@@ -32,6 +32,17 @@ import pytest
 if TYPE_CHECKING:
     import pathlib
 
+# Network errors that should cause E2E tests to be skipped rather than
+# reported as failures (the remote API is outside our control).
+_NETWORK_ERRORS: tuple[type[BaseException], ...] = (OSError, TimeoutError)
+
+try:
+    import httpx
+
+    _NETWORK_ERRORS = (*_NETWORK_ERRORS, httpx.ReadTimeout, httpx.ConnectTimeout, httpx.ConnectError)
+except ImportError:
+    pass
+
 
 # ---------------------------------------------------------------------------
 # Helpers — write mock Parquet files matching the HF dataset schema
@@ -315,9 +326,12 @@ class TestNavierStokesCylinderSourceE2E:
         """Build the source with a local cache directory."""
         from physicsnemo_curator.domains.mesh.sources.ns_cylinder import NavierStokesCylinderSource
 
-        self.source = NavierStokesCylinderSource(
-            cache_storage=str(tmp_path / "cache"),
-        )
+        try:
+            self.source = NavierStokesCylinderSource(
+                cache_storage=str(tmp_path / "cache"),
+            )
+        except _NETWORK_ERRORS as exc:
+            pytest.skip(f"HuggingFace API unreachable: {exc}")
         self.tmp_path = tmp_path
 
     def test_discovers_snapshots(self) -> None:

--- a/test/domains/mesh/test_pipeline.py
+++ b/test/domains/mesh/test_pipeline.py
@@ -35,6 +35,17 @@ from physicsnemo_curator.domains.mesh.filters.mean import MeanFilter  # noqa: E4
 from physicsnemo_curator.domains.mesh.sinks.mesh_writer import MeshSink  # noqa: E402
 from physicsnemo_curator.domains.mesh.sources.vtk import VTKSource  # noqa: E402
 
+# Network errors that should cause E2E tests to be skipped rather than
+# reported as failures (the remote API is outside our control).
+_NETWORK_ERRORS: tuple[type[BaseException], ...] = (OSError, TimeoutError)
+
+try:
+    import httpx
+
+    _NETWORK_ERRORS = (*_NETWORK_ERRORS, httpx.ReadTimeout, httpx.ConnectTimeout, httpx.ConnectError)
+except ImportError:
+    pass
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -1138,16 +1149,19 @@ class TestDrivAerMLRemotePipeline:
         import fsspec
 
         cache_dir = str(tmp_path / "hf_cache")
-        fs, root_path = fsspec.core.url_to_fs(_DRIVAERML_URL)
-        glob_expr = f"{root_path}/xNormal_p6*"
-        all_files = fs.glob(glob_expr)
-        files = sorted(f for f in all_files if f.endswith(".vtp"))
-        # Force download by caching each file
-        for remote_path in files:
-            local_path = pathlib.Path(cache_dir) / remote_path.lstrip("/")
-            if not local_path.exists():
-                local_path.parent.mkdir(parents=True, exist_ok=True)
-                fs.get(remote_path, str(local_path))
+        try:
+            fs, root_path = fsspec.core.url_to_fs(_DRIVAERML_URL)
+            glob_expr = f"{root_path}/xNormal_p6*"
+            all_files = fs.glob(glob_expr)
+            files = sorted(f for f in all_files if f.endswith(".vtp"))
+            # Force download by caching each file
+            for remote_path in files:
+                local_path = pathlib.Path(cache_dir) / remote_path.lstrip("/")
+                if not local_path.exists():
+                    local_path.parent.mkdir(parents=True, exist_ok=True)
+                    fs.get(remote_path, str(local_path))
+        except _NETWORK_ERRORS as exc:
+            pytest.skip(f"HuggingFace API unreachable: {exc}")
         # Point VTKSource at the cache directory
         self.source = VTKSource(cache_dir, warn_on_lost_data=False)
         self.tmp_path = tmp_path

--- a/test/domains/mesh/test_vti_and_boundaries.py
+++ b/test/domains/mesh/test_vti_and_boundaries.py
@@ -176,9 +176,7 @@ def _toy_domain():
 class TestInjection:
     def test_box_tunnel_generator(self):
         dm = _toy_domain()
-        gen = BoxTunnelBoundaries(
-            x_min=-40, x_max=80, y_min=-22, y_max=22, z_height=20, x_bl=-2.339, n_per_side=(4, 4)
-        )
+        gen = BoxTunnelBoundaries(x_min=-40, x_max=80, y_min=-22, y_max=22, z_height=20, x_bl=-2.339, n_per_side=(4, 4))
         out = inject_boundaries(dm, gen)
         assert set(out.boundary_names) == {"inlet", "outlet", "slip", "no_slip", "vehicle"}
         assert out.interior.n_points == 50  # interior preserved
@@ -194,9 +192,7 @@ class TestInjection:
 
     def test_boundary_injection_filter(self):
         dm = _toy_domain()
-        gen = BoxTunnelBoundaries(
-            x_min=-40, x_max=80, y_min=-22, y_max=22, z_height=20, x_bl=-2.339, n_per_side=(4, 4)
-        )
+        gen = BoxTunnelBoundaries(x_min=-40, x_max=80, y_min=-22, y_max=22, z_height=20, x_bl=-2.339, n_per_side=(4, 4))
         out = next(BoundaryInjectionFilter(gen)([dm].__iter__()))
         assert "inlet" in out.boundary_names
 

--- a/test/domains/mesh/test_vti_and_boundaries.py
+++ b/test/domains/mesh/test_vti_and_boundaries.py
@@ -1,0 +1,222 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the structured-grid (.vti) path and the generic boundary-condition
+synthesis / injection subsystem."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.requires("mesh")
+
+import numpy as np  # noqa: E402
+import pyvista as pv  # noqa: E402
+import torch  # noqa: E402
+from physicsnemo.mesh import Mesh  # noqa: E402
+from physicsnemo.mesh.domain_mesh import DomainMesh  # noqa: E402
+from tensordict import TensorDict  # noqa: E402
+
+from physicsnemo_curator.domains.mesh.boundaries import (  # noqa: E402
+    BoxTunnelBoundaries,
+    HemisphereBoundaries,
+    inject_boundaries,
+)
+from physicsnemo_curator.domains.mesh.boundaries import _geometry as geom  # noqa: E402
+from physicsnemo_curator.domains.mesh.filters.boundary_injection import BoundaryInjectionFilter  # noqa: E402
+from physicsnemo_curator.domains.mesh.sinks.grid_sidecar import GridSidecarSink  # noqa: E402
+from physicsnemo_curator.domains.mesh.sources.vti import VTISource  # noqa: E402
+
+
+def _create_vti(directory, name="grid.vti", dims=(4, 3, 2)):
+    """Write a small ImageData with a known scalar (= x + 10y + 100z) and vector."""
+    directory.mkdir(parents=True, exist_ok=True)
+    img = pv.ImageData(dimensions=dims, spacing=(1.0, 1.0, 1.0), origin=(0.0, 0.0, 0.0))
+    pts = img.points
+    img.point_data["s"] = (pts[:, 0] + 10 * pts[:, 1] + 100 * pts[:, 2]).astype(np.float64)
+    img.point_data["v"] = pts.astype(np.float64)
+    img.cell_data["c"] = np.arange(img.n_cells, dtype=np.float64)
+    path = directory / name
+    img.save(str(path))
+    return path
+
+
+# ---------------------------------------------------------------------------
+# VTISource
+# ---------------------------------------------------------------------------
+
+
+class TestVTISource:
+    def test_batch_sizes(self, tmp_path):
+        _create_vti(tmp_path / "g")
+        grid = next(VTISource(str(tmp_path / "g"))[0])
+        assert tuple(grid["point_data"].batch_size) == (2, 3, 4)  # (nz, ny, nx)
+        assert tuple(grid["cell_data"].batch_size) == (1, 2, 3)
+
+    def test_vtk_ordering(self, tmp_path):
+        _create_vti(tmp_path / "g")
+        grid = next(VTISource(str(tmp_path / "g"))[0])
+        s = grid["point_data"]["s"]
+        for z in range(2):
+            for y in range(3):
+                for x in range(4):
+                    assert abs(float(s[z, y, x]) - (x + 10 * y + 100 * z)) < 1e-9
+
+    def test_vector_field_shape(self, tmp_path):
+        _create_vti(tmp_path / "g")
+        grid = next(VTISource(str(tmp_path / "g"))[0])
+        assert tuple(grid["point_data"]["v"].shape) == (2, 3, 4, 3)
+
+    def test_grid_metadata(self, tmp_path):
+        _create_vti(tmp_path / "g")
+        grid = next(VTISource(str(tmp_path / "g"))[0])
+        assert grid["grid"]["dimensions"].tolist() == [4, 3, 2]
+        assert torch.allclose(grid["grid"]["spacing"], torch.ones(3, dtype=grid["grid"]["spacing"].dtype))
+
+    def test_fp32(self, tmp_path):
+        _create_vti(tmp_path / "g")
+        grid = next(VTISource(str(tmp_path / "g"), fp32=True)[0])
+        assert grid["point_data"]["s"].dtype == torch.float32
+
+    def test_non_vti_raises(self, tmp_path):
+        (tmp_path / "x.txt").write_text("nope")
+        with pytest.raises(ValueError, match="VTI extension"):
+            VTISource(str(tmp_path / "x.txt"))
+
+
+class TestGridSidecarSink:
+    def test_roundtrip(self, tmp_path):
+        _create_vti(tmp_path / "g", name="sample.vti")
+        source = VTISource(str(tmp_path / "g"))
+        out = tmp_path / "out"
+        sink = GridSidecarSink(output_dir=str(out))
+        sink.set_source(source)
+        paths = sink(source[0], 0)
+        assert paths[0].endswith("sample.grid")
+        loaded = TensorDict.load_memmap(paths[0])
+        original = next(source[0])
+        assert torch.allclose(loaded["point_data"]["s"], original["point_data"]["s"])
+        assert torch.allclose(loaded["cell_data"]["c"], original["cell_data"]["c"])
+
+
+# ---------------------------------------------------------------------------
+# Boundary geometry toolkit
+# ---------------------------------------------------------------------------
+
+
+class TestBoundaryGeometry:
+    def test_box_face_inward_normal(self):
+        bounds = ((-1.0, 1.0), (-1.0, 1.0), (0.0, 2.0))
+        inlet = geom.box_face_patch(bounds=bounds, face="x_min", n_per_side=(3, 3))
+        c = inlet.cells[0]
+        n = torch.linalg.cross(inlet.points[c[1]] - inlet.points[c[0]], inlet.points[c[2]] - inlet.points[c[0]])
+        assert float(n[0]) > 0  # inward at x_min is +x
+
+    def test_box_tunnel_keys(self):
+        bounds = ((-1.0, 1.0), (-1.0, 1.0), (0.0, 2.0))
+        bt = geom.box_tunnel_boundaries(bounds=bounds, x_bl=0.0, n_per_side=(3, 3))
+        assert set(bt.keys()) == {"inlet", "outlet", "slip", "no_slip"}
+
+    def test_box_tunnel_x_bl_out_of_range(self):
+        bounds = ((-1.0, 1.0), (-1.0, 1.0), (0.0, 2.0))
+        with pytest.raises(ValueError, match="x_bl"):
+            geom.box_tunnel_boundaries(bounds=bounds, x_bl=5.0, n_per_side=(3, 3))
+
+    def test_hemisphere_inward_winding(self):
+        hemi, equator = geom.build_hemisphere(10.0, n_theta=16, n_phi=8)
+        centroids = hemi.cell_centroids
+        normals = torch.linalg.cross(
+            hemi.points[hemi.cells[:, 1]] - hemi.points[hemi.cells[:, 0]],
+            hemi.points[hemi.cells[:, 2]] - hemi.points[hemi.cells[:, 0]],
+        )
+        # Inward => centroid . normal < 0 everywhere.
+        assert bool(((centroids * normals).sum(dim=-1) < 0).all())
+        assert equator.shape[0] == 16
+
+    def test_split_by_freestream_partitions(self):
+        hemi, _ = geom.build_hemisphere(10.0, n_theta=16, n_phi=8)
+        inlet, outlet = geom.split_by_freestream(hemi, torch.tensor([1.0, 0.0, 0.0]))
+        assert inlet.n_cells + outlet.n_cells == hemi.n_cells
+
+    def test_constrained_disk_no_holes(self):
+        hemi, equator = geom.build_hemisphere(10.0, n_theta=16, n_phi=8)
+        disk = geom.constrained_delaunay_disk(equator_xz=hemi.points[equator][:, [0, 2]], silhouette_xzs=[])
+        assert disk.n_cells > 0
+        # All disk points lie on y=0.
+        assert torch.allclose(disk.points[:, 1], torch.zeros(disk.n_points))
+
+
+# ---------------------------------------------------------------------------
+# Generators + injection
+# ---------------------------------------------------------------------------
+
+
+def _toy_domain():
+    interior = Mesh(points=torch.rand(50, 3) * torch.tensor([120.0, 44.0, 20.0]) - torch.tensor([40.0, 22.0, 0.0]))
+    vehicle = Mesh(
+        points=torch.tensor([[0.0, 0, 0], [1, 0, 0], [0, 1, 0]]),
+        cells=torch.tensor([[0, 1, 2]]),
+    )
+    return DomainMesh(interior=interior, boundaries={"vehicle": vehicle})
+
+
+class TestInjection:
+    def test_box_tunnel_generator(self):
+        dm = _toy_domain()
+        gen = BoxTunnelBoundaries(
+            x_min=-40, x_max=80, y_min=-22, y_max=22, z_height=20, x_bl=-2.339, n_per_side=(4, 4)
+        )
+        out = inject_boundaries(dm, gen)
+        assert set(out.boundary_names) == {"inlet", "outlet", "slip", "no_slip", "vehicle"}
+        assert out.interior.n_points == 50  # interior preserved
+
+    def test_box_tunnel_fixed_z_floor(self):
+        dm = _toy_domain()
+        gen = BoxTunnelBoundaries(
+            x_min=-40, x_max=80, y_min=-22, y_max=22, z_height=20, x_bl=-2.339, n_per_side=(4, 4), z_floor=0.0
+        )
+        out = inject_boundaries(dm, gen)
+        # Floor (no_slip) should sit at z=0.
+        assert torch.allclose(out.boundaries["no_slip"].points[:, 2], torch.zeros(out.boundaries["no_slip"].n_points))
+
+    def test_boundary_injection_filter(self):
+        dm = _toy_domain()
+        gen = BoxTunnelBoundaries(
+            x_min=-40, x_max=80, y_min=-22, y_max=22, z_height=20, x_bl=-2.339, n_per_side=(4, 4)
+        )
+        out = next(BoundaryInjectionFilter(gen)([dm].__iter__()))
+        assert "inlet" in out.boundary_names
+
+    def test_filter_passes_through_plain_mesh(self):
+        mesh = Mesh(points=torch.rand(5, 3))
+        gen = BoxTunnelBoundaries(x_min=-1, x_max=1, y_min=-1, y_max=1, z_height=2, x_bl=0.0)
+        out = next(BoundaryInjectionFilter(gen)([mesh].__iter__()))
+        assert isinstance(out, Mesh)
+
+    def test_hemisphere_generator(self):
+        interior = Mesh(points=torch.rand(200, 3) * torch.tensor([20.0, 10.0, 20.0]) - torch.tensor([10.0, 0.0, 10.0]))
+        vehicle = Mesh(
+            points=torch.tensor([[0.0, 0, 0], [1, 0, 0], [0, 0, 1]]),
+            cells=torch.tensor([[0, 1, 2]]),
+        )
+        dm = DomainMesh(
+            interior=interior,
+            boundaries={"vehicle": vehicle},
+            global_data={"U_inf": torch.tensor([1.0, 0.0, 0.0])},
+        )
+        gen = HemisphereBoundaries(radius=10.0, n_theta=16, n_phi=8)
+        out = inject_boundaries(dm, gen)
+        assert set(out.boundary_names) == {"inlet", "outlet", "symmetry", "vehicle"}

--- a/test/domains/mesh/test_vtk_generalization.py
+++ b/test/domains/mesh/test_vtk_generalization.py
@@ -1,0 +1,310 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the generalized VTKSource: Rust backend, per-path rules, array
+filtering, ``.stl`` support, domain-mesh pairing, and the new generic filters
+(clean / point_data_to_cell_data / global_data) and atomic MeshSink writes."""
+
+from __future__ import annotations
+
+import pathlib
+import stat
+
+import pytest
+
+pytestmark = pytest.mark.requires("mesh")
+
+import numpy as np  # noqa: E402
+import pyvista as pv  # noqa: E402
+import torch  # noqa: E402
+from physicsnemo.mesh import Mesh  # noqa: E402
+from physicsnemo.mesh.domain_mesh import DomainMesh  # noqa: E402
+
+from physicsnemo_curator.domains.mesh.filters.clean import CleanFilter  # noqa: E402
+from physicsnemo_curator.domains.mesh.filters.global_data import GlobalDataFilter  # noqa: E402
+from physicsnemo_curator.domains.mesh.filters.point_data_to_cell import PointDataToCellDataFilter  # noqa: E402
+from physicsnemo_curator.domains.mesh.sinks.mesh_writer import MeshSink  # noqa: E402
+from physicsnemo_curator.domains.mesh.sources.vtk import VTKSource  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_vtu(directory: pathlib.Path, name: str = "test.vtu") -> pathlib.Path:
+    """Write a small triangulated VTU with point + cell data."""
+    points = np.array([[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0]], dtype=np.float64)
+    cells = np.array([[3, 0, 1, 2], [3, 0, 2, 3]])
+    cell_types = np.array([5, 5])  # VTK_TRIANGLE
+    grid = pv.UnstructuredGrid(cells, cell_types, points)
+    grid.point_data["temperature"] = np.array([100.0, 200.0, 300.0, 400.0])
+    grid.point_data["pressure"] = np.array([1.0, 2.0, 3.0, 4.0])
+    grid.cell_data["velocity"] = np.array([10.0, 20.0])
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / name
+    grid.save(str(path))
+    return path
+
+
+def _create_vtp(directory: pathlib.Path, name: str = "surface.vtp") -> pathlib.Path:
+    """Write a small triangulated VTP surface with cell data."""
+    points = np.array([[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0]], dtype=np.float64)
+    faces = np.hstack([[3, 0, 1, 2], [3, 0, 2, 3]])
+    poly = pv.PolyData(points, faces)
+    poly.cell_data["wss"] = np.array([1.0, 2.0])
+    poly.point_data["p"] = np.array([5.0, 6.0, 7.0, 8.0])
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / name
+    poly.save(str(path))
+    return path
+
+
+def _create_stl(directory: pathlib.Path, name: str = "geom.stl") -> pathlib.Path:
+    """Write a small triangulated STL surface."""
+    points = np.array([[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0]], dtype=np.float32)
+    faces = np.hstack([[3, 0, 1, 2], [3, 0, 2, 3]])
+    poly = pv.PolyData(points, faces)
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / name
+    poly.save(str(path))
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Rust backend
+# ---------------------------------------------------------------------------
+
+
+class TestVTKSourceRustBackend:
+    def test_rust_reads_points_cells_data(self, tmp_path):
+        _create_vtu(tmp_path / "vtk")
+        source = VTKSource(str(tmp_path / "vtk"), backend="rust")
+        mesh = next(source[0])
+        assert mesh.n_points == 4
+        assert mesh.n_cells == 2
+        assert "temperature" in mesh.point_data
+        assert "velocity" in mesh.cell_data
+
+    def test_rust_matches_pyvista_points(self, tmp_path):
+        _create_vtu(tmp_path / "vtk")
+        rust_mesh = next(VTKSource(str(tmp_path / "vtk"), backend="rust")[0])
+        pv_mesh = next(VTKSource(str(tmp_path / "vtk"), backend="pyvista")[0])
+        assert torch.allclose(rust_mesh.points.double(), pv_mesh.points.double())
+
+    def test_rust_cell_centroids(self, tmp_path):
+        _create_vtu(tmp_path / "vtk")
+        source = VTKSource(str(tmp_path / "vtk"), backend="rust", point_source="cell_centroids")
+        mesh = next(source[0])
+        # 2 cells -> 2 centroid points, no cells, cell_data promoted to point_data.
+        assert mesh.n_points == 2
+        assert mesh.n_cells == 0
+        assert "velocity" in mesh.point_data
+
+    def test_rust_falls_back_for_stl(self, tmp_path):
+        # .stl is not a Rust-supported XML format; must transparently fall back.
+        _create_stl(tmp_path / "vtk")
+        mesh = next(VTKSource(str(tmp_path / "vtk"), backend="rust")[0])
+        assert isinstance(mesh, Mesh)
+        assert mesh.n_points == 4
+
+
+# ---------------------------------------------------------------------------
+# Per-path rules + reader-level array filtering
+# ---------------------------------------------------------------------------
+
+
+class TestPerPathAndArrayFilters:
+    @pytest.mark.parametrize("backend", ["pyvista", "rust"])
+    def test_key_filter_include(self, tmp_path, backend):
+        _create_vtu(tmp_path / "vtk")
+        source = VTKSource(
+            str(tmp_path / "vtk"),
+            backend=backend,
+            key_filters=[{"path_pattern": "**/*.vtu", "mode": "include", "keys": ["temperature"]}],
+        )
+        mesh = next(source[0])
+        keys = set(mesh.point_data.keys())
+        assert "temperature" in keys
+        assert "pressure" not in keys
+
+    @pytest.mark.parametrize("backend", ["pyvista", "rust"])
+    def test_key_filter_exclude(self, tmp_path, backend):
+        _create_vtu(tmp_path / "vtk")
+        source = VTKSource(
+            str(tmp_path / "vtk"),
+            backend=backend,
+            key_filters=[{"path_pattern": "**/*.vtu", "mode": "exclude", "keys": ["pressure"]}],
+        )
+        mesh = next(source[0])
+        keys = set(mesh.point_data.keys())
+        assert "temperature" in keys
+        assert "pressure" not in keys
+
+    def test_per_path_manifold_dim(self, tmp_path):
+        vtk_dir = tmp_path / "vtk"
+        _create_vtu(vtk_dir, "volume_a.vtu")
+        _create_vtu(vtk_dir, "surface_a.vtu")
+        source = VTKSource(
+            str(vtk_dir),
+            manifold_dim=[
+                {"pattern": "**/volume_*", "value": 0},
+                {"pattern": "**/surface_*", "value": 2},
+            ],
+        )
+        meshes = {pathlib.Path(source._files[i]).name: next(source[i]) for i in range(len(source))}
+        assert meshes["volume_a.vtu"].n_manifold_dims == 0
+        assert meshes["surface_a.vtu"].n_manifold_dims == 2
+
+
+# ---------------------------------------------------------------------------
+# .stl support
+# ---------------------------------------------------------------------------
+
+
+class TestStlSupport:
+    def test_reads_stl(self, tmp_path):
+        _create_stl(tmp_path / "vtk")
+        source = VTKSource(str(tmp_path / "vtk"))
+        assert len(source) == 1
+        mesh = next(source[0])
+        assert isinstance(mesh, Mesh)
+        assert mesh.n_points == 4
+
+    def test_stl_single_file(self, tmp_path):
+        stl = _create_stl(tmp_path)
+        source = VTKSource(str(stl))
+        assert len(source) == 1
+
+
+# ---------------------------------------------------------------------------
+# Domain-mesh pairing
+# ---------------------------------------------------------------------------
+
+
+class TestDomainMeshPairing:
+    def test_pairs_volume_and_boundary(self, tmp_path):
+        run = tmp_path / "data" / "run_1"
+        _create_vtu(run, "volume_1.vtu")
+        _create_vtp(run, "boundary_1.vtp")
+        source = VTKSource(
+            str(tmp_path / "data"),
+            volume_pattern="volume_*.vtu",
+            boundary_pattern="boundary_*.vtp",
+            boundary_name="vehicle",
+        )
+        assert len(source) == 1
+        domain = next(source[0])
+        assert isinstance(domain, DomainMesh)
+        assert "vehicle" in domain.boundary_names
+
+    def test_unpaired_falls_back_to_mesh(self, tmp_path):
+        run = tmp_path / "data" / "run_1"
+        _create_vtu(run, "volume_1.vtu")
+        _create_vtp(run, "boundary_1.vtp")
+        _create_stl(run, "geom.stl")  # unpaired
+        source = VTKSource(
+            str(tmp_path / "data"),
+            volume_pattern="volume_*.vtu",
+            boundary_pattern="boundary_*.vtp",
+        )
+        assert len(source) == 2  # one pair + one standalone
+        kinds = sorted(type(next(source[i])).__name__ for i in range(len(source)))
+        assert kinds == ["DomainMesh", "Mesh"]
+
+
+# ---------------------------------------------------------------------------
+# New generic filters
+# ---------------------------------------------------------------------------
+
+
+class TestCleanFilter:
+    def test_merges_duplicate_points(self):
+        # Two coincident points (0 and 2) should merge.
+        points = torch.tensor([[0.0, 0, 0], [1, 0, 0], [0, 0, 0], [1, 1, 0]])
+        cells = torch.tensor([[0, 1, 3], [2, 1, 3]])
+        mesh = Mesh(points=points, cells=cells)
+        out = next(CleanFilter()([mesh].__iter__()))
+        assert out.n_points == 3
+
+    def test_point_cloud_passthrough(self):
+        mesh = Mesh(points=torch.rand(10, 3))
+        out = next(CleanFilter()([mesh].__iter__()))
+        assert out.n_points == 10
+
+
+class TestPointDataToCellDataFilter:
+    def test_converts_and_drops_point_data(self):
+        points = torch.tensor([[0.0, 0, 0], [1, 0, 0], [0, 1, 0]])
+        cells = torch.tensor([[0, 1, 2]])
+        mesh = Mesh(points=points, cells=cells, point_data={"t": torch.tensor([1.0, 2.0, 3.0])})
+        out = next(PointDataToCellDataFilter()([mesh].__iter__()))
+        assert "t" in out.cell_data
+        assert torch.allclose(out.cell_data["t"], torch.tensor([2.0]))  # mean of 1,2,3
+        assert out.point_data is None or len(out.point_data.keys()) == 0
+
+    def test_keeps_point_data_when_requested(self):
+        points = torch.tensor([[0.0, 0, 0], [1, 0, 0], [0, 1, 0]])
+        cells = torch.tensor([[0, 1, 2]])
+        mesh = Mesh(points=points, cells=cells, point_data={"t": torch.tensor([1.0, 2.0, 3.0])})
+        out = next(PointDataToCellDataFilter(drop_point_data=False)([mesh].__iter__()))
+        assert "t" in out.cell_data
+        assert "t" in out.point_data
+
+
+class TestGlobalDataFilter:
+    def test_injects_constants(self):
+        mesh = Mesh(points=torch.rand(5, 3))
+        out = next(GlobalDataFilter(values={"U_inf": [30.0, 0.0, 0.0], "rho_inf": 1.225})([mesh].__iter__()))
+        assert torch.allclose(out.global_data["U_inf"], torch.tensor([30.0, 0.0, 0.0]))
+        assert torch.allclose(out.global_data["rho_inf"], torch.tensor(1.225))
+
+    def test_no_overwrite(self):
+        mesh = Mesh(points=torch.rand(5, 3), global_data={"rho_inf": torch.tensor(9.9)})
+        out = next(GlobalDataFilter(values={"rho_inf": 1.225}, overwrite=False)([mesh].__iter__()))
+        assert torch.allclose(out.global_data["rho_inf"], torch.tensor(9.9))
+
+    def test_empty_values_raises(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            GlobalDataFilter(values={})
+
+
+# ---------------------------------------------------------------------------
+# Atomic MeshSink writes
+# ---------------------------------------------------------------------------
+
+
+class TestAtomicMeshSink:
+    def test_overwrite_leaves_no_tmp_dirs(self, tmp_path):
+        _create_vtu(tmp_path / "vtk", "test.vtu")
+        source = VTKSource(str(tmp_path / "vtk"))
+        out = tmp_path / "out"
+        sink = MeshSink(output_dir=str(out), naming_template="m_{index}")
+        sink.set_source(source)
+        sink(source[0], 0)
+        sink(source[0], 0)  # overwrite
+        names = [p.name for p in out.iterdir()]
+        assert "m_0.pmsh" in names
+        assert not any(n.startswith(".tmp_") for n in names)
+
+    def test_group_readable(self, tmp_path):
+        _create_vtu(tmp_path / "vtk", "test.vtu")
+        source = VTKSource(str(tmp_path / "vtk"))
+        out = tmp_path / "out"
+        sink = MeshSink(output_dir=str(out), naming_template="m_{index}", group_readable=True)
+        sink.set_source(source)
+        paths = sink(source[0], 0)
+        mode = pathlib.Path(paths[0]).stat().st_mode
+        assert mode & stat.S_IRGRP


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Curator Pull Request

This PR adds some updates to the VTK pipeline.

First, it makes the domain mesh pairing a part of the VTK path, not just drivaerML.

Second, it enhances the VTK path with boundary condition injection.  THe drivaer ml example now does this, and I'll add ShiftSUV and HighLiftAero examples too in a followup.

Third, their is a path to move data from points to cells, which is needed especially in the high lift dataset.

Fourth, I've added support for VTI files, which we haven't got yet.  These are image based files, and they're writing out as memmap here in tensordict.  IF we need compression we can switch to h5 eventually.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo-curator/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo-curator/issues) is linked to this pull request.

## Dependencies

<!-- List any new dependencies needed, or write "None". -->
