### PR TITLE
Add OPERA radar source with valid-index tracking and NaN-aware statistics

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -342,7 +342,7 @@ Currently three domains are implemented:
 | Domain | Purpose | Import Gate |
 |--------|---------|-------------|
 | `mesh` | Computational mesh processing (VTK, LS-DYNA, ANSYS, DrivAer) | `physicsnemo.mesh` |
-| `da` | Data assimilation (ERA5, GFS, HRRR reanalysis data) | `xarray` |
+| `da` | Data assimilation (ERA5, GFS, HRRR, OPERA gridded data) | `xarray` |
 | `atm` | Atomic/molecular chemistry (ASE LMDB, molecular properties) | `nvalchemi.data` |
 
 Domains are **isolated** — they only depend on `core` and their own external

--- a/docs/domains/da.md
+++ b/docs/domains/da.md
@@ -47,6 +47,38 @@ ERA5's native 0.25° resolution (721 lat × 1440 lon).
 
 **Time range**: 1940-01-01 through ~2023-11-11, hourly resolution.
 
+### OPERASource
+
+Fetches [EUMETNET OPERA](https://eumetnet.github.io/openradardata-documentation/)
+pan-European radar composites from the CloudFerro S3 archive via
+{class}`earth2studio.data.OPERA`.  Each pipeline index maps to a single
+timestamp.
+
+```python
+from datetime import datetime
+from physicsnemo_curator.domains.da.sources.opera import OPERASource
+
+source = OPERASource(
+    times=[datetime(2024, 9, 1, 0, 0), datetime(2024, 9, 1, 0, 5)],
+    variables=["refc"],
+)
+```
+
+Each ``source[i]`` yields a {class}`xarray.DataArray` with dimensions
+``(time, variable, y, x)`` on OPERA's native Lambert Equal-Area grid, with
+2-D geographic coordinates ``_lat`` / ``_lon``.
+
+| Variable | Description |
+|----------|-------------|
+| ``refc`` | Maximum reflectivity (dBZ) |
+| ``tprate`` | Instantaneous rain rate |
+| ``tp01`` | 1-hour accumulated precipitation |
+
+**Time range**: composites are published every 15 minutes before
+2024-07-01 and every 5 minutes from 2024-07-01 onward; requested
+timestamps must align to the interval for their era.  Variables with
+differing pixel resolutions cannot be mixed in a single source.
+
 ### DataArrayStatsFilter
 
 Computes running statistical moments (mean, variance, skewness, min, max)
@@ -139,6 +171,6 @@ The `da` domain depends on:
 | Package | Purpose |
 |---------|---------|
 | [xarray](https://docs.xarray.dev/) | Labelled multi-dimensional arrays |
-| [earth2studio](https://nvidia.github.io/earth2studio/) | Weather/climate data backends (ERA5, HRRR, GFS) |
+| [earth2studio](https://nvidia.github.io/earth2studio/) | Weather/climate data backends (ERA5, HRRR, GFS, OPERA) |
 | [zarr](https://zarr.readthedocs.io/) | Zarr v3 store I/O |
 | [gcsfs](https://gcsfs.readthedocs.io/) | Google Cloud Storage filesystem for ARCO data |

--- a/docs/domains/da.md
+++ b/docs/domains/da.md
@@ -100,6 +100,16 @@ Each variable gets its own group with arrays: ``mean``, ``variance``,
 multiple workers write to the same path, results are merged using
 Chan's parallel Welford algorithm.
 
+Non-finite values (NaN/±Inf) are skipped **per element**, so gridpoints
+that are missing in some samples — for example pixels outside a radar
+domain — do not poison the statistics of their neighbors.  The
+per-element tally of finite observations is stored alongside the
+accumulator state as ``welford_n``, which is what makes the parallel
+merge exact when a gridpoint is observed by some workers but not others.
+Gridpoints with no finite observations at all report NaN for ``mean``,
+``variance``, ``skewness``, ``min``, and ``max``.  The scalar ``count``
+attribute still counts every sample seen, including all-NaN ones.
+
 ### ZarrSink
 
 Writes incoming DataArrays to a Zarr v3 store.  Each variable is written to

--- a/docs/domains/da.md
+++ b/docs/domains/da.md
@@ -120,6 +120,29 @@ sink = ZarrSink(
 **Sharding** (Zarr v3) groups multiple chunks into larger shard files,
 reducing the number of objects in cloud storage.
 
+**Tracking which indices were written.** Pre-allocated stores are sized
+up front, so an unwritten slot is indistinguishable from one legitimately
+containing fill values.  Pass ``track_valid=True`` to record a per-index
+boolean ``valid`` array, flipped only once *every* pre-allocated variable
+has been written at that index:
+
+```python
+sink = ZarrSink(
+    output_path="output.zarr",
+    n_indices=72,
+    variables=["refc"],
+    track_valid=True,
+)
+# ... run the pipeline ...
+sink.finalize()  # only once no workers are writing
+```
+
+The array is chunked ``(1,)`` while writing so concurrent workers never
+contend for the same chunk.  ``finalize()`` rechunks it into a single
+chunk for fast reads and must be called after all workers have finished.
+This is useful for resuming a partial ingest, or for skipping gaps when a
+remote archive is missing timestamps.
+
 ### NetCDF4Sink
 
 Writes incoming DataArrays to NetCDF4 files.  Each variable gets its own

--- a/src/physicsnemo_curator/domains/da/__init__.py
+++ b/src/physicsnemo_curator/domains/da/__init__.py
@@ -33,12 +33,14 @@ from physicsnemo_curator.domains.da.sinks.zarr_writer import ZarrSink
 from physicsnemo_curator.domains.da.sources.era5 import ERA5Source
 from physicsnemo_curator.domains.da.sources.gfs import GFSSource
 from physicsnemo_curator.domains.da.sources.hrrr import HRRRSource
+from physicsnemo_curator.domains.da.sources.opera import OPERASource
 
 # Register submodule and components with the global registry.
 registry.register_submodule("da", "DataArray data curation (xarray.DataArray)", "xarray")
 registry.register_source("da", ERA5Source)
 registry.register_source("da", GFSSource)
 registry.register_source("da", HRRRSource)
+registry.register_source("da", OPERASource)
 registry.register_filter("da", DataArrayStatsFilter)
 registry.register_sink("da", ZarrSink)
 registry.register_sink("da", NetCDF4Sink)
@@ -48,6 +50,7 @@ __all__ = [
     "ERA5Source",
     "GFSSource",
     "HRRRSource",
+    "OPERASource",
     "NetCDF4Sink",
     "ZarrSink",
 ]

--- a/src/physicsnemo_curator/domains/da/filters/stats.py
+++ b/src/physicsnemo_curator/domains/da/filters/stats.py
@@ -765,9 +765,9 @@ def _merge_moment_datasets(datasets: list[xr.Dataset]) -> xr.Dataset:
         ref_var = next(iter(ds.data_vars.values()))
         shape = ref_var.shape
 
-        # Extract min/max with fallback to NaN (never-observed pixels)
-        min_val = ds["min"].values.astype(np.float64) if "min" in ds else np.full(shape, np.nan, dtype=np.float64)
-        max_val = ds["max"].values.astype(np.float64) if "max" in ds else np.full(shape, np.nan, dtype=np.float64)
+        # Extract min/max with fallback to inf/-inf
+        min_val = ds["min"].values.astype(np.float64) if "min" in ds else np.full(shape, np.inf, dtype=np.float64)
+        max_val = ds["max"].values.astype(np.float64) if "max" in ds else np.full(shape, -np.inf, dtype=np.float64)
 
         # Prefer exact Welford state if all three variables available
         if "welford_mean" in ds and "welford_m2" in ds and "welford_m3" in ds:

--- a/src/physicsnemo_curator/domains/da/filters/stats.py
+++ b/src/physicsnemo_curator/domains/da/filters/stats.py
@@ -507,6 +507,7 @@ class _MomentAccumulator:
         self._mean: np.ndarray | None = None
         self._m2: np.ndarray | None = None
         self._m3: np.ndarray | None = None
+        self._n: np.ndarray | None = None  # per-element finite observation counts
         self._min: np.ndarray | None = None
         self._max: np.ndarray | None = None
 
@@ -541,54 +542,75 @@ class _MomentAccumulator:
     def _update_sample(self, x: np.ndarray) -> None:
         """Update accumulators with a single sample (Welford's online).
 
+        Non-finite values (NaN/±Inf) are skipped per element so missing
+        pixels (e.g. outside a radar domain) do not poison the running
+        mean.  ``self._count`` still increments once per sample so callers
+        can track how many frames were processed.
+
         Parameters
         ----------
         x : np.ndarray
             Sample array with shape matching the remaining dims.
         """
         x = np.asarray(x, dtype=np.float64)
+        finite = np.isfinite(x)
 
         if self._mean is None:
             self._mean = np.zeros_like(x)
             self._m2 = np.zeros_like(x)
             self._m3 = np.zeros_like(x)
-            self._min = x.copy()
-            self._max = x.copy()
+            self._n = np.zeros(x.shape, dtype=np.int64)
+            self._min = np.full_like(x, np.nan)
+            self._max = np.full_like(x, np.nan)
+
+        # After the None guard above, all accumulators are guaranteed to be set.
+        assert self._m2 is not None  # noqa: S101
+        assert self._m3 is not None  # noqa: S101
+        assert self._n is not None  # noqa: S101
+        assert self._min is not None  # noqa: S101
+        assert self._max is not None  # noqa: S101
 
         self._count += 1
-        n = self._count
+        if not finite.any():
+            return
 
-        delta = x - self._mean
-        delta_n = delta / n
-        term1 = delta * delta_n * (n - 1)
+        # Dense arithmetic with the increments zeroed at non-finite elements.
+        n_old = self._n
+        n_new = n_old + finite
+        delta = np.where(finite, x - self._mean, 0.0)
+        delta_n = np.where(finite, delta / np.maximum(n_new, 1), 0.0)
+        term1 = delta * delta_n * n_old
 
         # Update M3 before M2 (needs old M2 value)
-        self._m3 += term1 * delta_n * (n - 2) - 3 * delta_n * self._m2
+        self._m3 += term1 * delta_n * (n_new - 2) - 3.0 * delta_n * self._m2
         # Update M2
         self._m2 += term1
         # Update mean
         self._mean += delta_n
+        self._n = n_new
 
-        # Min/max
-        self._min = np.minimum(self._min, x)  # ty: ignore[no-matching-overload]
-        self._max = np.maximum(self._max, x)  # ty: ignore[no-matching-overload]
+        # Min/max over finite observations only
+        self._min = np.where(finite, np.fmin(self._min, x), self._min)
+        self._max = np.where(finite, np.fmax(self._max, x), self._max)
 
     def finalize(self) -> xr.Dataset:
         """Compute final statistics and return as an xarray Dataset.
 
         The output includes both user-facing statistics and the raw
         Welford accumulator state (``welford_mean``, ``welford_m2``,
-        ``welford_m3``) so that runs can be resumed exactly without
-        recovering state from derived statistics.
+        ``welford_m3``, ``welford_n``) so that runs can be resumed exactly
+        without recovering state from derived statistics.
 
         Returns
         -------
         xr.Dataset
             Dataset with variables: ``mean``, ``variance``,
             ``skewness``, ``min``, ``max``, ``welford_mean``,
-            ``welford_m2``, ``welford_m3``.  The attribute ``count``
-            stores the total number of samples (elements along the
-            reduced dimensions) incorporated.
+            ``welford_m2``, ``welford_m3``, ``welford_n``.  The attribute
+            ``count`` stores the total number of samples (elements along
+            the reduced dimensions) seen, including all-NaN samples.
+            Elements with no finite observations have NaN mean/min/max
+            /variance/skewness.
         """
         if self._mean is None or self._count == 0:
             return xr.Dataset()
@@ -596,28 +618,31 @@ class _MomentAccumulator:
         # After the None guard above, all accumulators are guaranteed to be set.
         assert self._m2 is not None  # noqa: S101
         assert self._m3 is not None  # noqa: S101
+        assert self._n is not None  # noqa: S101
         assert self._min is not None  # noqa: S101
         assert self._max is not None  # noqa: S101
 
-        mean = self._mean
-        variance = self._m2 / self._count if self._count > 0 else np.zeros_like(self._mean)
-
-        # Compute skewness from the third central moment.
+        observed = self._n > 0
+        mean = np.where(observed, self._mean, np.nan)
         with np.errstate(divide="ignore", invalid="ignore"):
+            variance = np.where(observed, self._m2 / self._n, np.nan)
+            # Compute skewness from the third central moment.
             m2_safe = np.where(self._m2 > 0, self._m2, np.nan)
-            skewness = (np.sqrt(self._count) * self._m3) / np.power(m2_safe, 1.5)
+            skewness = (np.sqrt(self._n) * self._m3) / np.power(m2_safe, 1.5)
             skewness = np.where(np.isfinite(skewness), skewness, 0.0)
+            skewness = np.where(observed, skewness, np.nan)
 
         data_vars: dict[str, tuple[list[str], np.ndarray]] = {
             "mean": (self._remaining_dims, mean),
             "variance": (self._remaining_dims, variance),
             "skewness": (self._remaining_dims, skewness),
-            "min": (self._remaining_dims, self._min),
-            "max": (self._remaining_dims, self._max),
+            "min": (self._remaining_dims, self._min.copy()),
+            "max": (self._remaining_dims, self._max.copy()),
             # Raw Welford state for exact resumption
             "welford_mean": (self._remaining_dims, self._mean.copy()),
             "welford_m2": (self._remaining_dims, self._m2.copy()),
             "welford_m3": (self._remaining_dims, self._m3.copy()),
+            "welford_n": (self._remaining_dims, self._n.astype(np.float64)),
         }
 
         ds = xr.Dataset(
@@ -650,7 +675,17 @@ def _open_stats_zarr(path: str | pathlib.Path) -> xr.Dataset:
     attrs = dict(group.attrs)
 
     # Known stat variable names written by _MomentAccumulator.finalize()
-    stat_vars = {"mean", "variance", "skewness", "min", "max", "welford_mean", "welford_m2", "welford_m3"}
+    stat_vars = {
+        "mean",
+        "variance",
+        "skewness",
+        "min",
+        "max",
+        "welford_mean",
+        "welford_m2",
+        "welford_m3",
+        "welford_n",
+    }
 
     data_vars: dict[str, tuple[list[str], np.ndarray]] = {}
     dims: list[str] = []
@@ -689,9 +724,15 @@ def _merge_moment_datasets(datasets: list[xr.Dataset]) -> xr.Dataset:
 
     Each dataset must contain ``mean``, ``variance``, ``skewness``,
     ``min``, ``max`` data variables and a ``count`` attribute.
-    If ``welford_mean``, ``welford_m2``, ``welford_m3`` are present,
-    the Welford state is used directly for exact merging; otherwise it
-    is recovered from the derived statistics (backward compatible).
+    If ``welford_mean``, ``welford_m2``, ``welford_m3`` (and optionally
+    ``welford_n``) are present, the Welford state is used directly for
+    exact merging; otherwise it is recovered from the derived statistics
+    (backward compatible).
+
+    When ``welford_n`` is present, Chan's merge is applied **per element**
+    so pixels that were missing (NaN) in one shard but observed in another
+    combine correctly.  The scalar ``count`` attribute is still the sum of
+    sample counts (e.g. frames processed) across inputs.
 
     Parameters
     ----------
@@ -706,23 +747,27 @@ def _merge_moment_datasets(datasets: list[xr.Dataset]) -> xr.Dataset:
     if len(datasets) == 1:
         return datasets[0]
 
-    def _extract_state(ds: xr.Dataset) -> tuple[int, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
-        """Extract (count, mean, m2, m3, min, max) from a dataset."""
-        n = int(ds.attrs.get("count", 0))
-        if n == 0:
+    def _extract_state(
+        ds: xr.Dataset,
+    ) -> tuple[int, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """Extract (sample_count, n, mean, m2, m3, min, max) from a dataset.
+
+        ``sample_count`` is the scalar attrs count (frames/samples seen).
+        ``n`` is the per-element finite observation count used for Chan merge.
+        """
+        sample_count = int(ds.attrs.get("count", 0))
+        if sample_count == 0 and len(ds.data_vars) == 0:
             # Empty dataset - return zeros
-            ref_var = next(iter(ds.data_vars.values()), None)
-            shape = ref_var.shape if ref_var is not None else ()
-            zeros = np.zeros(shape, dtype=np.float64)
-            return 0, zeros, zeros.copy(), zeros.copy(), zeros.copy(), zeros.copy()
+            zeros = np.zeros((), dtype=np.float64)
+            return 0, zeros, zeros.copy(), zeros.copy(), zeros.copy(), zeros.copy(), zeros.copy()
 
         # Get a reference shape from any available variable
         ref_var = next(iter(ds.data_vars.values()))
         shape = ref_var.shape
 
-        # Extract min/max with fallback to inf/-inf
-        min_val = ds["min"].values.astype(np.float64) if "min" in ds else np.full(shape, np.inf, dtype=np.float64)
-        max_val = ds["max"].values.astype(np.float64) if "max" in ds else np.full(shape, -np.inf, dtype=np.float64)
+        # Extract min/max with fallback to NaN (never-observed pixels)
+        min_val = ds["min"].values.astype(np.float64) if "min" in ds else np.full(shape, np.nan, dtype=np.float64)
+        max_val = ds["max"].values.astype(np.float64) if "max" in ds else np.full(shape, np.nan, dtype=np.float64)
 
         # Prefer exact Welford state if all three variables available
         if "welford_mean" in ds and "welford_m2" in ds and "welford_m3" in ds:
@@ -738,12 +783,16 @@ def _merge_moment_datasets(datasets: list[xr.Dataset]) -> xr.Dataset:
             # Recover from derived statistics (legacy stores)
             mean = ds["mean"].values.astype(np.float64)
             var = ds["variance"].values.astype(np.float64)
-            m2 = var * n
+            m2 = var * sample_count
             if "skewness" in ds:
                 skew = ds["skewness"].values.astype(np.float64)
                 with np.errstate(divide="ignore", invalid="ignore"):
                     m2_safe = np.where(m2 > 0, m2, np.nan)
-                    m3 = np.where(m2 > 0, skew * np.power(m2_safe, 1.5) / np.sqrt(n), 0.0)
+                    m3 = np.where(
+                        m2 > 0,
+                        skew * np.power(m2_safe, 1.5) / np.sqrt(max(sample_count, 1)),
+                        0.0,
+                    )
             else:
                 m3 = np.zeros(shape, dtype=np.float64)
         else:
@@ -757,48 +806,109 @@ def _merge_moment_datasets(datasets: list[xr.Dataset]) -> xr.Dataset:
             m2 = np.zeros(shape, dtype=np.float64)
             m3 = np.zeros(shape, dtype=np.float64)
 
-        return n, mean, m2, m3, min_val, max_val
+        if "welford_n" in ds:
+            n = ds["welford_n"].values.astype(np.float64)
+        else:
+            # Legacy stores: treat every element as observed in all samples,
+            # except positions that are already non-finite in the mean.
+            n = np.full(shape, float(sample_count), dtype=np.float64)
+            n[~np.isfinite(mean)] = 0.0
+
+        # Zero out Welford state where nothing was observed.
+        unobserved = n <= 0
+        if np.any(unobserved):
+            mean = mean.copy()
+            m2 = m2.copy()
+            m3 = m3.copy()
+            mean[unobserved] = 0.0
+            m2[unobserved] = 0.0
+            m3[unobserved] = 0.0
+
+        return sample_count, n, mean, m2, m3, min_val, max_val
 
     # Initialize from first dataset
-    n_a, mean_a, m2_a, m3_a, min_a, max_a = _extract_state(datasets[0])
+    sample_count_a, n_a, mean_a, m2_a, m3_a, min_a, max_a = _extract_state(datasets[0])
 
     # Merge remaining datasets one at a time.
     for ds_b in datasets[1:]:
-        n_b, mean_b, m2_b, m3_b, min_b, max_b = _extract_state(ds_b)
+        sample_count_b, n_b, mean_b, m2_b, m3_b, min_b, max_b = _extract_state(ds_b)
 
-        if n_b == 0:
+        if sample_count_b == 0 and not np.any(n_b > 0):
             continue  # Skip empty datasets
-        if n_a == 0:
-            n_a, mean_a, m2_a, m3_a, min_a, max_a = n_b, mean_b, m2_b, m3_b, min_b, max_b
+        if sample_count_a == 0 and not np.any(n_a > 0):
+            sample_count_a, n_a, mean_a, m2_a, m3_a, min_a, max_a = (
+                sample_count_b,
+                n_b,
+                mean_b,
+                m2_b,
+                m3_b,
+                min_b,
+                max_b,
+            )
             continue
 
-        n_ab = n_a + n_b
-        delta = mean_b - mean_a
-        delta2 = delta * delta
+        sample_count_a = sample_count_a + sample_count_b
 
-        # Chan's parallel formulas.
-        mean_ab = (n_a * mean_a + n_b * mean_b) / n_ab
-        m2_ab = m2_a + m2_b + delta2 * n_a * n_b / n_ab
-        m3_ab = (
-            m3_a
-            + m3_b
-            + delta * delta2 * n_a * n_b * (n_a - n_b) / (n_ab * n_ab)
-            + 3 * delta * (n_a * m2_b - n_b * m2_a) / n_ab
-        )
+        both = (n_a > 0) & (n_b > 0)
+        only_b = (n_a <= 0) & (n_b > 0)
+        # only_a: keep A's state (already in the copied buffers below)
+
+        n_ab = n_a + n_b
+        mean_ab = mean_a.copy()
+        m2_ab = m2_a.copy()
+        m3_ab = m3_a.copy()
+        min_ab = min_a.copy()
+        max_ab = max_a.copy()
+
+        if np.any(both):
+            n_a_b = n_a[both]
+            n_b_b = n_b[both]
+            n_ab_b = n_ab[both]
+            mean_a_b = mean_a[both]
+            mean_b_b = mean_b[both]
+            m2_a_b = m2_a[both]
+            m2_b_b = m2_b[both]
+            m3_a_b = m3_a[both]
+            m3_b_b = m3_b[both]
+
+            delta = mean_b_b - mean_a_b
+            delta2 = delta * delta
+
+            # Chan's parallel formulas (per-element where both sides observed).
+            mean_ab[both] = (n_a_b * mean_a_b + n_b_b * mean_b_b) / n_ab_b
+            m2_ab[both] = m2_a_b + m2_b_b + delta2 * n_a_b * n_b_b / n_ab_b
+            m3_ab[both] = (
+                m3_a_b
+                + m3_b_b
+                + delta * delta2 * n_a_b * n_b_b * (n_a_b - n_b_b) / (n_ab_b * n_ab_b)
+                + 3.0 * delta * (n_a_b * m2_b_b - n_b_b * m2_a_b) / n_ab_b
+            )
+            min_ab[both] = np.fmin(min_a[both], min_b[both])
+            max_ab[both] = np.fmax(max_a[both], max_b[both])
+
+        if np.any(only_b):
+            mean_ab[only_b] = mean_b[only_b]
+            m2_ab[only_b] = m2_b[only_b]
+            m3_ab[only_b] = m3_b[only_b]
+            min_ab[only_b] = min_b[only_b]
+            max_ab[only_b] = max_b[only_b]
 
         n_a = n_ab
         mean_a = mean_ab
         m2_a = m2_ab
         m3_a = m3_ab
-        min_a = np.minimum(min_a, min_b)
-        max_a = np.maximum(max_a, max_b)
+        min_a = min_ab
+        max_a = max_ab
 
     # Finalize merged statistics.
-    variance = m2_a / n_a if n_a > 0 else np.zeros_like(mean_a)
+    observed = n_a > 0
     with np.errstate(divide="ignore", invalid="ignore"):
+        variance = np.where(observed, m2_a / n_a, np.nan)
         m2_safe = np.where(m2_a > 0, m2_a, np.nan)
         skewness = (np.sqrt(n_a) * m3_a) / np.power(m2_safe, 1.5)
         skewness = np.where(np.isfinite(skewness), skewness, 0.0)
+        skewness = np.where(observed, skewness, np.nan)
+    mean_out = np.where(observed, mean_a, np.nan)
 
     # Reconstruct the Dataset with the same structure as the inputs.
     ref = datasets[0]
@@ -806,7 +916,7 @@ def _merge_moment_datasets(datasets: list[xr.Dataset]) -> xr.Dataset:
     coords = dict(ref.coords.items())
 
     data_vars = {
-        "mean": (dims, mean_a),
+        "mean": (dims, mean_out),
         "variance": (dims, variance),
         "skewness": (dims, skewness),
         "min": (dims, min_a),
@@ -814,6 +924,7 @@ def _merge_moment_datasets(datasets: list[xr.Dataset]) -> xr.Dataset:
         "welford_mean": (dims, mean_a.copy()),
         "welford_m2": (dims, m2_a),
         "welford_m3": (dims, m3_a),
+        "welford_n": (dims, n_a.astype(np.float64)),
     }
 
-    return xr.Dataset(data_vars=data_vars, coords=coords, attrs={"count": int(n_a)})
+    return xr.Dataset(data_vars=data_vars, coords=coords, attrs={"count": int(sample_count_a)})

--- a/src/physicsnemo_curator/domains/da/sinks/zarr_writer.py
+++ b/src/physicsnemo_curator/domains/da/sinks/zarr_writer.py
@@ -164,6 +164,14 @@ class ZarrSink(Sink["xr.DataArray"]):
         overwritten during pre-allocation.  If *False* (default), existing
         variable groups are preserved and only missing variables are
         created, allowing pipelines to resume from partial runs.
+    track_valid : bool
+        If *True* and the store is pre-allocated, create a 1-D ``valid``
+        boolean array of length *n_indices*, chunked per time step
+        (``chunks=(1,)``).  ``valid[index]`` is set only once every
+        pre-allocated variable has been written at that index, so a partial
+        write is never mistaken for a complete one.  Call :meth:`finalize`
+        once writing is complete to rechunk ``valid`` into a single chunk
+        for faster reads.
     storage_options : dict[str, Any] | None
         Extra keyword arguments for the fsspec filesystem.  Use this
         to provide credentials for remote stores (e.g., S3 keys).
@@ -211,6 +219,7 @@ class ZarrSink(Sink["xr.DataArray"]):
 
     name: ClassVar[str] = "Zarr Writer"
     description: ClassVar[str] = "Write DataArrays to a Zarr store with configurable chunking and sharding"
+    _VALID_NAME: ClassVar[str] = "valid"
 
     _DEFAULT_CHUNKS: ClassVar[dict[str, int]] = {"time": 1, "lat": 721, "lon": 1440}
 
@@ -248,6 +257,7 @@ class ZarrSink(Sink["xr.DataArray"]):
         n_indices: int | None = None,
         variables: list[str] | None = None,
         overwrite: bool = False,
+        track_valid: bool = False,
         storage_options: dict[str, Any] | None = None,
     ) -> None:
         self._log = get_logger(self)
@@ -259,7 +269,9 @@ class ZarrSink(Sink["xr.DataArray"]):
         self._n_indices = n_indices
         self._variables = variables
         self._overwrite = overwrite
+        self._track_valid = track_valid
         self._preallocated = False
+        self._finalized = False
 
         # Lazy-initialized in workers (can't pickle stores with async resources)
         self._store: FsspecStore | LocalStore | None = None
@@ -284,6 +296,13 @@ class ZarrSink(Sink["xr.DataArray"]):
         if (n_indices is None) != (variables is None):
             msg = "n_indices and variables must both be provided or both be omitted."
             raise ValueError(msg)
+
+        if self._track_valid:
+            if variables is not None and self._VALID_NAME in variables:
+                msg = f"Variable name '{self._VALID_NAME}' is reserved when track_valid=True."
+                raise ValueError(msg)
+            if n_indices is None:
+                self._log.warning("track_valid=True has no effect without n_indices and variables.")
 
         # Pre-allocate the store if schema is provided.
         if n_indices is not None and variables is not None:
@@ -421,6 +440,9 @@ class ZarrSink(Sink["xr.DataArray"]):
 
             self._log.debug("Pre-allocated Zarr array: %s/%s (metadata only)", self._output_path, var_name)
 
+        if self._track_valid:
+            self._ensure_valid_array(root, n_indices)
+
         self._preallocated = True
         if vars_to_create:
             self._log.info(
@@ -432,6 +454,147 @@ class ZarrSink(Sink["xr.DataArray"]):
 
         # Reset store so workers create their own (FsspecStore can't be pickled)
         self._store = None
+
+    def _ensure_valid_array(self, root: zarr.Group, n_indices: int) -> None:
+        """Create the per-time-step ``valid`` flag array if missing.
+
+        Chunked as ``(1,)`` so concurrent workers can safely set individual
+        indices without contending for the same chunk.  Call :meth:`finalize`
+        after writing completes to rechunk into a single contiguous array.
+        """
+        name = self._VALID_NAME
+        preserved: np.ndarray | None = None
+        if name in root:
+            existing = root[name]
+            if self._overwrite:
+                del root[name]
+            elif isinstance(existing, zarr.Array) and existing.shape == (n_indices,):
+                if existing.chunks == (1,):
+                    self._log.debug("Reusing existing '%s' array at: %s", name, self._output_path)
+                    return
+                # A previous run called finalize(), collapsing the array into a
+                # single chunk. Restore per-index chunking (carrying the flags
+                # over) so concurrent workers cannot clobber each other.
+                preserved = np.asarray(existing[:], dtype=np.bool_)
+                self._log.info("Re-chunking '%s' array for concurrent writes: %s", name, self._output_path)
+                del root[name]
+            elif isinstance(existing, zarr.Array):
+                # Pre-allocation never resizes existing data arrays, so honoring
+                # a new length here would leave the store dimensionally
+                # inconsistent and unreadable by xarray.
+                msg = (
+                    f"Existing '{name}' array has length {existing.shape[0]} but n_indices={n_indices}. "
+                    "n_indices cannot change for an existing store; pass overwrite=True to rebuild it."
+                )
+                raise ValueError(msg)
+            else:
+                self._log.warning("Replacing incompatible '%s' array at: %s", name, self._output_path)
+                del root[name]
+
+        arr = root.create_array(
+            name,
+            shape=(n_indices,),
+            chunks=(1,),
+            dtype=np.bool_,
+            fill_value=False,
+            dimension_names=[self._append_dim],
+        )
+        if preserved is not None:
+            arr[:] = preserved
+        self._log.info(
+            "Pre-allocated '%s' array: shape=(%d,), chunks=(1,)",
+            name,
+            n_indices,
+        )
+
+    def _index_complete(self, paths: list[str]) -> bool:
+        """Report whether every pre-allocated variable was written at an index.
+
+        A partial write must not count as complete: a resumed run would skip
+        the index and leave the remaining variables at their fill value.
+
+        Parameters
+        ----------
+        paths : list[str]
+            Zarr group paths written for this index.
+
+        Returns
+        -------
+        bool
+            *True* when *paths* covers every pre-allocated variable.
+        """
+        if not paths:
+            return False
+        if self._variables is None:
+            return True
+        return {f"{self._output_path}/{name!s}" for name in self._variables} <= set(paths)
+
+    def _mark_valid(self, index: int) -> None:
+        """Mark *index* as successfully written in the ``valid`` array.
+
+        Raises
+        ------
+        RuntimeError
+            If :meth:`finalize` has already run on this sink.  The array is
+            then a single chunk, so marking would be a read-modify-write of
+            the whole array and concurrent workers would clobber each other.
+        """
+        if not self._track_valid or not self._preallocated:
+            return
+        if self._finalized:
+            msg = (
+                f"Cannot mark index {index}: finalize() already collapsed the "
+                f"'{self._VALID_NAME}' array into one chunk. Construct a new "
+                f"{type(self).__name__} to write more indices."
+            )
+            raise RuntimeError(msg)
+        if self._root_group is None:
+            self._root_group = zarr.open_group(self._get_store(), mode="r+")
+        arr = self._root_group[self._VALID_NAME]
+        assert isinstance(arr, zarr.Array), f"Expected Array, got {type(arr)}"
+        arr[index] = True
+
+    def finalize(self) -> None:
+        """Rechunk the ``valid`` array into a single chunk for fast reads.
+
+        Must be called only when no workers are writing.  No-op when
+        *track_valid* is ``False`` or the store was not pre-allocated.
+        Afterwards this sink can no longer mark indices; construct a new one
+        to write more.
+        """
+        if not self._track_valid or not self._preallocated:
+            return
+
+        # Force a fresh root group handle (may have been reset after pickling).
+        self._root_group = None
+        root = zarr.open_group(self._get_store(), mode="r+")
+        name = self._VALID_NAME
+        if name not in root:
+            self._log.warning("finalize(): '%s' array missing at %s", name, self._output_path)
+            return
+
+        old = root[name]
+        assert isinstance(old, zarr.Array), f"Expected Array, got {type(old)}"
+        n_indices = int(old.shape[0])
+        data = np.asarray(old[:], dtype=np.bool_)
+        del root[name]
+        new = root.create_array(
+            name,
+            shape=(n_indices,),
+            chunks=(n_indices,),
+            dtype=np.bool_,
+            fill_value=False,
+            dimension_names=[self._append_dim],
+        )
+        new[:] = data
+        self._root_group = root
+        self._finalized = True
+        self._log.info(
+            "Finalized '%s' array: shape=(%d,), chunks=(%d,)",
+            name,
+            n_indices,
+            n_indices,
+        )
 
     def __call__(self, items: Iterator[xr.DataArray], index: int) -> list[str]:
         """Consume DataArrays and write each variable to the Zarr store.
@@ -464,6 +627,9 @@ class ZarrSink(Sink["xr.DataArray"]):
             written = self._write_dataarray(da, index)
             paths.extend(written)
             self._log.debug("Wrote %d groups for DataArray", len(written))
+
+        if self._index_complete(paths):
+            self._mark_valid(index)
 
         self._log.info("Write complete: %d paths (%.2fs)", len(paths), time.perf_counter() - t0)
         return paths

--- a/src/physicsnemo_curator/domains/da/sources/opera.py
+++ b/src/physicsnemo_curator/domains/da/sources/opera.py
@@ -1,0 +1,248 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""EUMETNET OPERA composite radar data source via earth2studio.
+
+Fetches pan-European OPERA composite radar products from the EUMETNET Open
+Radar Data archive on CloudFerro S3 using :class:`earth2studio.data.OPERA`.
+Data is provided on a Lambert Equal-Area (LAEA) grid with native dimensions
+``(y, x)`` and geographic coordinates ``_lat`` / ``_lon``.
+
+Each pipeline index corresponds to a single timestamp, and the returned
+:class:`xarray.DataArray` has dimensions ``(time, variable, y, x)`` with a
+single time step.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from physicsnemo_curator.core.base import Param, Source
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from datetime import datetime
+
+    import xarray as xr
+
+
+def _import_opera(**kwargs: Any) -> Any:
+    """Lazily import and instantiate the earth2studio OPERA data source."""
+    mod = importlib.import_module("earth2studio.data")
+    cls = mod.OPERA
+    return cls(**kwargs)
+
+
+def _import_lexicon() -> Any:
+    """Lazily import the OPERA lexicon for variable validation."""
+    mod = importlib.import_module("earth2studio.lexicon")
+    return mod.OPERALexicon
+
+
+class OPERASource(Source["xr.DataArray"]):
+    """Fetch OPERA composite radar fields from the EUMETNET archive.
+
+    `OPERA <https://eumetnet.github.io/openradardata-documentation/>`_ provides
+    pan-European weather radar composites (reflectivity, rain rate, hourly
+    accumulation) on a Lambert Equal-Area grid.  Data is accessed via
+    :mod:`earth2studio` from the public CloudFerro S3 archive.
+
+    Parameters
+    ----------
+    times : list[datetime]
+        Timestamps to fetch (UTC).  Must align to the era-appropriate OPERA
+        composite interval (15-minute before 2024-07-01, 5-minute from
+        2024-07-01 onward).
+    variables : list[str]
+        Earth2studio variable identifiers (``"refc"``, ``"tprate"``, or
+        ``"tp01"``).  Must be present in
+        :class:`earth2studio.lexicon.OPERALexicon`.  Variables with
+        different pixel resolutions cannot be mixed in one call.
+    cache : bool
+        Whether to cache downloaded ODIM HDF5 files locally.  Default ``False``.
+    async_workers : int
+        Maximum concurrent async fetch tasks.  Default ``16``.
+    async_timeout : int
+        Total timeout in seconds for a synchronous fetch call.  Default ``600``.
+    retries : int
+        Retry attempts per failed download.  Default ``3``.
+
+    Examples
+    --------
+    >>> from datetime import datetime
+    >>> source = OPERASource(
+    ...     times=[datetime(2024, 9, 1, 0)],
+    ...     variables=["refc"],
+    ... )  # doctest: +SKIP
+    >>> len(source)  # doctest: +SKIP
+    1
+    >>> da = next(source[0])  # doctest: +SKIP
+    >>> da.dims  # doctest: +SKIP
+    ('time', 'variable', 'y', 'x')
+
+    Note
+    ----
+    - OPERA documentation: `EUMETNET Open Radar Data <https://eumetnet.github.io/openradardata-documentation/>`_
+    - earth2studio: `NVIDIA earth2studio <https://nvidia.github.io/earth2studio/>`_
+    """
+
+    name: ClassVar[str] = "OPERA"
+    description: ClassVar[str] = "EUMETNET OPERA composite radar via earth2studio"
+
+    @classmethod
+    def params(cls) -> list[Param]:
+        """Return parameter descriptors for the OPERA source."""
+        return [
+            Param(
+                name="times",
+                description="Comma-separated ISO timestamps (e.g. 2024-09-01T00:00)",
+                type=str,
+            ),
+            Param(
+                name="variables",
+                description="Comma-separated earth2studio variable IDs (e.g. refc,tprate)",
+                type=str,
+            ),
+            Param(
+                name="cache",
+                description="Cache downloaded ODIM HDF5 files locally",
+                type=bool,
+                default=False,
+            ),
+            Param(
+                name="async_workers",
+                description="Maximum concurrent async fetch tasks",
+                type=int,
+                default=16,
+            ),
+            Param(
+                name="async_timeout",
+                description="Total timeout in seconds for a fetch call",
+                type=int,
+                default=600,
+            ),
+            Param(
+                name="retries",
+                description="Retry attempts per failed download",
+                type=int,
+                default=3,
+            ),
+        ]
+
+    def __init__(
+        self,
+        times: list[datetime],
+        variables: list[str],
+        *,
+        cache: bool = False,
+        async_workers: int = 16,
+        async_timeout: int = 600,
+        retries: int = 3,
+    ) -> None:
+        if not times:
+            msg = "times must be a non-empty list of datetime objects."
+            raise ValueError(msg)
+        if not variables:
+            msg = "variables must be a non-empty list of variable IDs."
+            raise ValueError(msg)
+
+        self._times = list(times)
+        self._variables = list(variables)
+        self._cache = cache
+        self._async_workers = async_workers
+        self._async_timeout = async_timeout
+        self._retries = retries
+
+        lexicon = _import_lexicon()
+        unknown = [v for v in self._variables if v not in lexicon]
+        if unknown:
+            msg = f"Variables not found in OPERALexicon: {unknown}"
+            raise ValueError(msg)
+
+        self._backend = _import_opera(
+            cache=cache,
+            verbose=False,
+            async_workers=async_workers,
+            async_timeout=async_timeout,
+            retries=retries,
+        )
+
+    def __getstate__(self) -> dict[str, Any]:
+        """Return picklable state, excluding the unpicklable backend."""
+        state = self.__dict__.copy()
+        state.pop("_backend", None)
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        """Restore state and lazily re-create the backend in worker processes."""
+        self.__dict__.update(state)
+        self._backend = _import_opera(
+            cache=self._cache,
+            verbose=False,
+            async_workers=self._async_workers,
+            async_timeout=self._async_timeout,
+            retries=self._retries,
+        )
+
+    def __len__(self) -> int:
+        """Return the number of timestamps in this source."""
+        return len(self._times)
+
+    def __getitem__(self, index: int) -> Generator[xr.DataArray]:
+        """Fetch OPERA data for the *index*-th timestamp.
+
+        Parameters
+        ----------
+        index : int
+            Positional index into *times*.  Negative indices are supported.
+
+        Yields
+        ------
+        xr.DataArray
+            A single DataArray with dims ``(time, variable, y, x)`` where
+            ``time`` is length-1.
+
+        Raises
+        ------
+        IndexError
+            If *index* is out of range.
+        """
+        n = len(self._times)
+        if index < 0:
+            index += n
+        if index < 0 or index >= n:
+            msg = f"Index {index} out of range for source with {n} timestamps."
+            raise IndexError(msg)
+
+        time = self._times[index]
+        result = self._backend(time=[time], variable=self._variables)
+        yield result
+
+    @property
+    def times(self) -> list[datetime]:
+        """Return the list of timestamps in this source."""
+        return list(self._times)
+
+    @property
+    def variables(self) -> list[str]:
+        """Return the list of variable IDs in this source."""
+        return list(self._variables)
+
+    @property
+    def cache(self) -> bool:
+        """Return whether local caching is enabled."""
+        return self._cache

--- a/test/domains/da/test_opera.py
+++ b/test/domains/da/test_opera.py
@@ -1,0 +1,179 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 - 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for OPERASource."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.requires("da")
+
+
+def _make_opera_dataarray() -> object:
+    import numpy as np
+    import xarray as xr
+
+    ysize, xsize = 4, 5
+    lat = np.ones((ysize, xsize), dtype=np.float32)
+    lon = np.zeros((ysize, xsize), dtype=np.float32)
+    data = np.zeros((1, 1, ysize, xsize), dtype=np.float32)
+    return xr.DataArray(
+        data=data,
+        dims=["time", "variable", "y", "x"],
+        coords={
+            "time": [np.datetime64("2024-09-01T00:00")],
+            "variable": ["refc"],
+            "y": np.arange(ysize),
+            "x": np.arange(xsize),
+        },
+    ).assign_coords({"_lat": (("y", "x"), lat), "_lon": (("y", "x"), lon)})
+
+
+class TestOPERASource:
+    """Unit tests for OPERASource."""
+
+    def test_params_list(self) -> None:
+        """params() exposes the constructor arguments for the CLI."""
+        from physicsnemo_curator.domains.da.sources.opera import OPERASource
+
+        names = [p.name for p in OPERASource.params()]
+        assert "times" in names
+        assert "variables" in names
+        assert "cache" in names
+
+    def test_name_and_description(self) -> None:
+        """Registry metadata is populated."""
+        from physicsnemo_curator.domains.da.sources.opera import OPERASource
+
+        assert OPERASource.name == "OPERA"
+        assert len(OPERASource.description) > 0
+
+    @patch("physicsnemo_curator.domains.da.sources.opera._import_lexicon")
+    def test_unknown_variable_raises(self, mock_lexicon: MagicMock) -> None:
+        """An identifier absent from the lexicon is rejected."""
+        from physicsnemo_curator.domains.da.sources.opera import OPERASource
+
+        mock_lexicon.return_value = {"refc": "DBZH"}
+        with pytest.raises(ValueError, match="OPERALexicon"):
+            OPERASource(times=[datetime(2024, 9, 1)], variables=["not_a_var"])
+
+    def test_empty_times_raises(self) -> None:
+        """An empty time list is rejected."""
+        from physicsnemo_curator.domains.da.sources.opera import OPERASource
+
+        with pytest.raises(ValueError, match="times must be"):
+            OPERASource(times=[], variables=["refc"])
+
+    def test_empty_variables_raises(self) -> None:
+        """An empty variable list is rejected."""
+        from physicsnemo_curator.domains.da.sources.opera import OPERASource
+
+        with pytest.raises(ValueError, match="variables must be"):
+            OPERASource(times=[datetime(2024, 9, 1)], variables=[])
+
+    @patch("physicsnemo_curator.domains.da.sources.opera._import_lexicon")
+    def test_len(self, mock_lexicon: MagicMock) -> None:
+        """Length is one pipeline index per requested time."""
+        from physicsnemo_curator.domains.da.sources.opera import OPERASource
+
+        mock_lexicon.return_value = {"refc": "DBZH"}
+        times = [datetime(2024, 9, 1, 0, 0), datetime(2024, 9, 1, 0, 15)]
+        assert len(OPERASource(times=times, variables=["refc"])) == 2
+
+    @patch("physicsnemo_curator.domains.da.sources.opera._import_opera")
+    @patch("physicsnemo_curator.domains.da.sources.opera._import_lexicon")
+    def test_getitem_returns_dataarray(
+        self,
+        mock_lexicon: MagicMock,
+        mock_import: MagicMock,
+    ) -> None:
+        from physicsnemo_curator.domains.da.sources.opera import OPERASource
+
+        mock_lexicon.return_value = {"refc": "DBZH"}
+        backend = MagicMock(return_value=_make_opera_dataarray())
+        mock_import.return_value = backend
+
+        source = OPERASource(times=[datetime(2024, 9, 1, 0, 0)], variables=["refc"])
+        da = next(source[0])
+        assert da.dims == ("time", "variable", "y", "x")
+        backend.assert_called_once()
+
+    @patch("physicsnemo_curator.domains.da.sources.opera._import_opera")
+    @patch("physicsnemo_curator.domains.da.sources.opera._import_lexicon")
+    def test_index_out_of_bounds(
+        self,
+        mock_lexicon: MagicMock,
+        mock_import: MagicMock,
+    ) -> None:
+        from physicsnemo_curator.domains.da.sources.opera import OPERASource
+
+        mock_lexicon.return_value = {"refc": "DBZH"}
+        mock_import.return_value = MagicMock()
+        source = OPERASource(times=[datetime(2024, 9, 1)], variables=["refc"])
+        with pytest.raises(IndexError):
+            next(source[1])
+
+    @patch("physicsnemo_curator.domains.da.sources.opera._import_opera")
+    @patch("physicsnemo_curator.domains.da.sources.opera._import_lexicon")
+    def test_negative_index(
+        self,
+        mock_lexicon: MagicMock,
+        mock_import: MagicMock,
+    ) -> None:
+        from physicsnemo_curator.domains.da.sources.opera import OPERASource
+
+        mock_lexicon.return_value = {"refc": "DBZH"}
+        backend = MagicMock(return_value=_make_opera_dataarray())
+        mock_import.return_value = backend
+
+        times = [datetime(2024, 9, 1, 0, 0), datetime(2024, 9, 1, 0, 5)]
+        source = OPERASource(times=times, variables=["refc"])
+        next(source[-1])
+        assert backend.call_args.kwargs["time"] == [times[-1]]
+
+    @patch("physicsnemo_curator.domains.da.sources.opera._import_opera")
+    @patch("physicsnemo_curator.domains.da.sources.opera._import_lexicon")
+    def test_pickle_roundtrip(
+        self,
+        mock_lexicon: MagicMock,
+        mock_import: MagicMock,
+    ) -> None:
+        """Source survives pickling so worker processes can rebuild the backend."""
+        import pickle
+
+        from physicsnemo_curator.domains.da.sources.opera import OPERASource
+
+        mock_lexicon.return_value = {"refc": "DBZH"}
+        mock_import.return_value = MagicMock()
+
+        source = OPERASource(times=[datetime(2024, 9, 1)], variables=["refc"], cache=False)
+        restored = pickle.loads(pickle.dumps(source))
+
+        assert len(restored) == len(source)
+        assert restored.times == source.times
+        assert restored.variables == source.variables
+        assert restored.cache == source.cache
+
+    def test_source_registered(self) -> None:
+        import physicsnemo_curator.domains.da  # noqa: F401 — triggers registration
+        from physicsnemo_curator.core.registry import registry
+
+        names = [s.name for s in registry.list_sources("da")]
+        assert "OPERA" in names

--- a/test/domains/da/test_pipeline.py
+++ b/test/domains/da/test_pipeline.py
@@ -32,6 +32,10 @@ import pytest
 if TYPE_CHECKING:
     from pathlib import Path
 
+    import zarr
+
+    from physicsnemo_curator.domains.da.sinks.zarr_writer import ZarrSink
+
 pytestmark = pytest.mark.requires("da")
 
 # ---------------------------------------------------------------------------
@@ -866,6 +870,41 @@ class TestHRRRSource:
 # ===================================================================
 
 
+def _valid_sink(
+    tmp_path: Path, *, n_indices: int = 3, variables: list[str] | None = None, **kwargs: object
+) -> ZarrSink:
+    """Build a pre-allocated ZarrSink with valid-index tracking enabled."""
+    from physicsnemo_curator.domains.da.sinks.zarr_writer import ZarrSink
+
+    return ZarrSink(
+        output_path=str(tmp_path / "output.zarr"),
+        chunks={"time": 1, "lat": _LATS_N, "lon": _LONS_N},
+        n_indices=n_indices,
+        variables=variables if variables is not None else ["t2m"],
+        track_valid=True,
+        **kwargs,  # type: ignore[arg-type]
+    )
+
+
+def _write_index(sink: ZarrSink, index: int, variables: list[str] | None = None) -> list[str]:
+    """Write one synthetic DataArray to *sink* at *index*."""
+    da = _make_dataarray(variables=variables if variables is not None else ["t2m"], n_lat=_LATS_N, n_lon=_LONS_N)
+
+    def gen():  # type: ignore[override]
+        yield da
+
+    return sink(gen(), index=index)
+
+
+def _valid_array(tmp_path: Path) -> zarr.Array:
+    """Reopen the store and return its ``valid`` array."""
+    import zarr
+
+    arr = zarr.open_group(str(tmp_path / "output.zarr"), mode="r")["valid"]
+    assert isinstance(arr, zarr.Array)
+    return arr
+
+
 class TestZarrSink:
     """Unit tests for ZarrSink."""
 
@@ -973,6 +1012,84 @@ class TestZarrSink:
 
         sink = ZarrSink(output_path=str(tmp_path / "output.zarr"))
         assert sink.output_path == str(tmp_path / "output.zarr")
+
+    def test_track_valid_lifecycle(self, tmp_path: Path) -> None:
+        """The valid array is per-index chunked while writing and collapsed by finalize()."""
+        import numpy as np
+
+        sink = _valid_sink(tmp_path, overwrite=True)
+
+        valid = _valid_array(tmp_path)
+        assert valid.shape == (3,)
+        assert valid.chunks == (1,)
+        assert valid.dtype == np.dtype("bool")
+        assert not bool(valid[0])
+
+        _write_index(sink, 0)
+        _write_index(sink, 2)
+        assert list(np.asarray(_valid_array(tmp_path)[:])) == [True, False, True]
+
+        sink.finalize()
+        valid = _valid_array(tmp_path)
+        assert valid.chunks == (3,)
+        assert list(np.asarray(valid[:])) == [True, False, True]
+
+    def test_track_valid_partial_write_not_marked(self, tmp_path: Path) -> None:
+        """An index missing some pre-allocated variables must not be marked valid."""
+        sink = _valid_sink(tmp_path, n_indices=2, variables=["t2m", "q2m"], overwrite=True)
+
+        # Only one of the two pre-allocated variables arrives.
+        _write_index(sink, 0, variables=["t2m"])
+        assert not bool(_valid_array(tmp_path)[0])
+
+        _write_index(sink, 1, variables=["t2m", "q2m"])
+        assert bool(_valid_array(tmp_path)[1])
+
+    def test_track_valid_resume_preserves_existing(self, tmp_path: Path) -> None:
+        """Resuming with overwrite=False preserves existing valid flags."""
+        _write_index(_valid_sink(tmp_path, overwrite=True), 1)
+
+        _valid_sink(tmp_path, overwrite=False)
+
+        valid = _valid_array(tmp_path)
+        assert bool(valid[1])
+        assert not bool(valid[0])
+        assert valid.chunks == (1,)
+
+    def test_track_valid_resume_after_finalize_rechunks(self, tmp_path: Path) -> None:
+        """Resuming a finalized store restores per-index chunking but keeps flags."""
+        import numpy as np
+
+        sink = _valid_sink(tmp_path, overwrite=True)
+        _write_index(sink, 1)
+        sink.finalize()
+        assert _valid_array(tmp_path).chunks == (3,)
+
+        # Resuming must not leave the array single-chunked, or concurrent
+        # workers would race on the same chunk when marking their index.
+        _valid_sink(tmp_path, overwrite=False)
+
+        valid = _valid_array(tmp_path)
+        assert valid.chunks == (1,)
+        assert list(np.asarray(valid[:])) == [False, True, False]
+
+    def test_track_valid_rejects_invalid_configuration(self, tmp_path: Path) -> None:
+        """A reserved variable name or a changed n_indices is refused up front."""
+        with pytest.raises(ValueError, match="reserved"):
+            _valid_sink(tmp_path, variables=["valid", "t2m"])
+
+        _valid_sink(tmp_path, n_indices=2, overwrite=True)
+        with pytest.raises(ValueError, match="n_indices cannot change"):
+            _valid_sink(tmp_path, n_indices=4)
+
+    def test_track_valid_rejects_write_after_finalize(self, tmp_path: Path) -> None:
+        """Marking after finalize() would be an unsafe whole-array rewrite."""
+        sink = _valid_sink(tmp_path, overwrite=True)
+        _write_index(sink, 0)
+        sink.finalize()
+
+        with pytest.raises(RuntimeError, match="finalize"):
+            _write_index(sink, 1)
 
 
 # ===================================================================

--- a/test/domains/da/test_pipeline.py
+++ b/test/domains/da/test_pipeline.py
@@ -1483,6 +1483,201 @@ class TestMomentsFilter:
         expected_var = np.var(all_values)
         np.testing.assert_allclose(ds["variance"].values.flat[0], expected_var, rtol=1e-10)
 
+    def test_skips_nan_pixels(self, tmp_path: Path) -> None:
+        """NaN pixels must not poison the running mean for finite neighbors."""
+        import numpy as np
+        import xarray as xr
+
+        from physicsnemo_curator.domains.da.filters.stats import DataArrayStatsFilter as MomentsFilter
+
+        filt = MomentsFilter(output=str(tmp_path / "stats.zarr"), dims=("time",))
+
+        for i in range(3):
+            # Left column finite, right column always NaN
+            data = np.array([[[1.0 + i, np.nan], [2.0 + i, np.nan]]], dtype=np.float64)
+            da = xr.DataArray(
+                data=data,
+                dims=["time", "lat", "lon"],
+                coords={
+                    "time": [np.datetime64(f"2020-01-01T0{i}")],
+                    "lat": [0.0, 1.0],
+                    "lon": [0.0, 1.0],
+                },
+            )
+
+            def gen(d=da):  # type: ignore[override]
+                yield d
+
+            list(filt(gen()))
+
+        filt.flush()
+        ds = xr.open_zarr(str(tmp_path / "stats.zarr" / "data"))
+
+        assert ds.attrs["count"] == 3
+        # Finite column: mean of 1,2,3 and 2,3,4
+        np.testing.assert_allclose(ds["mean"].values[:, 0], [2.0, 3.0])
+        # Always-NaN column stays NaN
+        assert np.isnan(ds["mean"].values[:, 1]).all()
+        assert np.isnan(ds["min"].values[:, 1]).all()
+        assert "welford_n" in ds
+        np.testing.assert_array_equal(ds["welford_n"].values[:, 0], [3, 3])
+        np.testing.assert_array_equal(ds["welford_n"].values[:, 1], [0, 0])
+
+    def test_skips_all_nan_sample(self, tmp_path: Path) -> None:
+        """A sample with no finite values counts as seen but contributes nothing."""
+        import numpy as np
+        import xarray as xr
+
+        from physicsnemo_curator.domains.da.filters.stats import DataArrayStatsFilter as MomentsFilter
+
+        filt = MomentsFilter(output=str(tmp_path / "stats.zarr"), dims=("time",))
+
+        # Middle sample is entirely absent, as when an archive drops a composite.
+        samples = [
+            np.array([[1.0, 1.0], [3.0, 3.0]]),
+            np.array([[np.nan, np.nan], [np.nan, np.nan]]),
+            np.array([[3.0, 3.0], [5.0, 5.0]]),
+        ]
+        for i, arr in enumerate(samples):
+            da = xr.DataArray(
+                data=arr[None, ...],
+                dims=["time", "lat", "lon"],
+                coords={
+                    "time": [np.datetime64(f"2020-01-01T0{i}")],
+                    "lat": [0.0, 1.0],
+                    "lon": [0.0, 1.0],
+                },
+            )
+
+            def gen(d=da):  # type: ignore[override]
+                yield d
+
+            list(filt(gen()))
+
+        filt.flush()
+        ds = xr.open_zarr(str(tmp_path / "stats.zarr" / "data"))
+
+        # Every sample is tallied, but only the finite ones shape the moments.
+        assert ds.attrs["count"] == 3
+        np.testing.assert_array_equal(ds["welford_n"].values, np.full((2, 2), 2))
+        np.testing.assert_allclose(ds["mean"].values[0], [2.0, 2.0])
+        np.testing.assert_allclose(ds["mean"].values[1], [4.0, 4.0])
+        np.testing.assert_allclose(ds["min"].values[0], [1.0, 1.0])
+        np.testing.assert_allclose(ds["max"].values[1], [5.0, 5.0])
+
+    def test_merge_legacy_store_without_welford_n(self, tmp_path: Path) -> None:
+        """Stores predating welford_n still merge via the reconstructed count."""
+        import numpy as np
+        import xarray as xr
+
+        from physicsnemo_curator.domains.da.filters.stats import DataArrayStatsFilter as MomentsFilter
+        from physicsnemo_curator.domains.da.filters.stats import _merge_moment_datasets
+
+        def _flush_shard(path: Path, values: list[np.ndarray]) -> None:
+            filt = MomentsFilter(output=str(path), dims=("time",))
+            for i, arr in enumerate(values):
+                da = xr.DataArray(
+                    data=arr[None, ...],
+                    dims=["time", "lat", "lon"],
+                    coords={
+                        "time": [np.datetime64(f"2020-01-01T0{i}")],
+                        "lat": [0.0, 1.0],
+                        "lon": [0.0, 1.0],
+                    },
+                )
+
+                def gen(d=da):  # type: ignore[override]
+                    yield d
+
+                list(filt(gen()))
+            filt.flush()
+
+        shard_a = tmp_path / "a.zarr"
+        shard_b = tmp_path / "b.zarr"
+        _flush_shard(shard_a, [np.array([[1.0, np.nan], [10.0, np.nan]]), np.array([[3.0, np.nan], [30.0, np.nan]])])
+        _flush_shard(shard_b, [np.array([[np.nan, 2.0], [np.nan, 20.0]]), np.array([[np.nan, 4.0], [np.nan, 40.0]])])
+
+        loaded = [xr.open_zarr(str(shard_a / "data")).load(), xr.open_zarr(str(shard_b / "data")).load()]
+        expected = _merge_moment_datasets(loaded)
+
+        # Emulate a store written before welford_n existed: no per-element count,
+        # and unobserved pixels left NaN because the old accumulator let a single
+        # NaN sample poison them. The count is rebuilt from those NaN positions.
+        legacy = []
+        for ds in loaded:
+            never_seen = ds["welford_n"].values == 0
+            old = ds.drop_vars("welford_n").copy()
+            for name in ("mean", "welford_mean"):
+                poisoned = old[name].values.copy()
+                poisoned[never_seen] = np.nan
+                old[name] = (old[name].dims, poisoned)
+            legacy.append(old)
+
+        merged = _merge_moment_datasets(legacy)
+
+        assert merged.attrs["count"] == expected.attrs["count"]
+        for stat in ("mean", "variance", "min", "max"):
+            np.testing.assert_allclose(merged[stat].values, expected[stat].values)
+
+    def test_merge_nan_aware_shards(self, tmp_path: Path) -> None:
+        """Merging shards combines per-pixel counts without NaN poisoning."""
+        import numpy as np
+        import xarray as xr
+
+        from physicsnemo_curator.domains.da.filters.stats import (
+            DataArrayStatsFilter as MomentsFilter,
+        )
+        from physicsnemo_curator.domains.da.filters.stats import _merge_moment_datasets
+
+        def _flush_shard(path: Path, values: list[np.ndarray]) -> None:
+            filt = MomentsFilter(output=str(path), dims=("time",))
+            for i, arr in enumerate(values):
+                da = xr.DataArray(
+                    data=arr[None, ...],
+                    dims=["time", "lat", "lon"],
+                    coords={
+                        "time": [np.datetime64(f"2020-01-01T0{i}")],
+                        "lat": [0.0, 1.0],
+                        "lon": [0.0, 1.0],
+                    },
+                )
+
+                def gen(d=da):  # type: ignore[override]
+                    yield d
+
+                list(filt(gen()))
+            filt.flush()
+
+        shard_a = tmp_path / "a.zarr"
+        shard_b = tmp_path / "b.zarr"
+        # Shard A observes only left column
+        _flush_shard(
+            shard_a,
+            [
+                np.array([[1.0, np.nan], [10.0, np.nan]]),
+                np.array([[3.0, np.nan], [30.0, np.nan]]),
+            ],
+        )
+        # Shard B observes only right column
+        _flush_shard(
+            shard_b,
+            [
+                np.array([[np.nan, 2.0], [np.nan, 20.0]]),
+                np.array([[np.nan, 4.0], [np.nan, 40.0]]),
+            ],
+        )
+
+        merged = _merge_moment_datasets(
+            [
+                xr.open_zarr(str(shard_a / "data")).load(),
+                xr.open_zarr(str(shard_b / "data")).load(),
+            ]
+        )
+        assert merged.attrs["count"] == 4
+        np.testing.assert_allclose(merged["mean"].values[:, 0], [2.0, 20.0])
+        np.testing.assert_allclose(merged["mean"].values[:, 1], [3.0, 30.0])
+        assert not np.isnan(merged["mean"].values).any()
+
     def test_properties(self) -> None:
         """Properties return the configured values."""
         from physicsnemo_curator.domains.da.filters.stats import DataArrayStatsFilter as MomentsFilter

--- a/uv.lock
+++ b/uv.lock
@@ -983,37 +983,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cublas" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-runtime" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cufft" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufile" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-cupti" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-curand" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusolver" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusparse" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvtx" },
 ]
 
 [[package]]
@@ -1182,8 +1182,8 @@ wheels = [
 
 [[package]]
 name = "earth2studio"
-version = "0.15.0a0"
-source = { git = "https://github.com/NVIDIA/earth2studio.git?rev=main#c3d1625fefcfdacd94a48a114f106bafde41f94f" }
+version = "0.18.0a0"
+source = { git = "https://github.com/NVIDIA/earth2studio.git?rev=main#166b2d2e09ecc4783c622fae0295ccf11d4d7c9f" }
 dependencies = [
     { name = "cftime" },
     { name = "fsspec" },
@@ -1193,6 +1193,7 @@ dependencies = [
     { name = "huggingface-hub" },
     { name = "loguru" },
     { name = "netcdf4" },
+    { name = "obstore" },
     { name = "pandas" },
     { name = "pyarrow" },
     { name = "pygrib" },
@@ -2964,6 +2965,55 @@ wheels = [
 ]
 
 [[package]]
+name = "obstore"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/2f/f83afaab7945509d72245b2b00af0b4834ce78fdd2d9ae9f0ad1a3036a91/obstore-0.11.0.tar.gz", hash = "sha256:a2f55163bcd348b4a60d12e6893eac50eddc742bad8032a1705d49140b992204", size = 130565, upload-time = "2026-06-25T18:29:49.405Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/b2/00c213e7e5ca8065f97e37e55294adab836e3f6a88b23e4029069aaecf95/obstore-0.11.0-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:42f36546c7ac44dbab1173d2330a8a1b1a3f0e37950e553b8c904e3dd0744b25", size = 5491935, upload-time = "2026-06-25T18:28:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/37/6a6b9a5e15a8a37c24d14317a87648097c4888593b588510c03c030d2e90/obstore-0.11.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:687bb9d3962d568b7c439c5d0c6fea19b2749862a8e5c8eebd0c058c4eccde9e", size = 4672619, upload-time = "2026-06-25T18:28:33.852Z" },
+    { url = "https://files.pythonhosted.org/packages/28/f9/6745ce8c4f7bfac19dc14a4438b48a2e93a689b92b0cecfc695e41a4e8b1/obstore-0.11.0-cp311-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:010b51578c7514a41719d795cdb7a1e6529be509dac3772e477187a59422bb97", size = 5072806, upload-time = "2026-06-25T18:28:36.127Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/18/991d3b3cdd851c0225e55f3dc45b47fd9e249827d188995011469f805132/obstore-0.11.0-cp311-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cfaa8129a3f5d8518a3a75184d4b02348db0f6263177cd1f0951f6568243cc9e", size = 5303777, upload-time = "2026-06-25T18:28:37.89Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/e9/90e56015a45b5e56a84fc3188c4e5fb088b288d41992c73a629e10df6760/obstore-0.11.0-cp311-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c790a5cb9ff2970d1f464a6a708d734dce9939e9f668cb6708c5dba5d61589b2", size = 5493871, upload-time = "2026-06-25T18:28:39.981Z" },
+    { url = "https://files.pythonhosted.org/packages/66/02/f1744091d59ce71c5523174eb860fbb298275c901e89b9ea6fbf3e654a33/obstore-0.11.0-cp311-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:827113e12fe8088e0281a9d57b90b2b8dbc8a6ffe3b15dadb9baa5feb3d266c1", size = 5361913, upload-time = "2026-06-25T18:28:42.089Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/59/3f47822683ee2b6db8685faa25829946d6343a561251ec2704548455d946/obstore-0.11.0-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a2ff6d3ed553298828fb760b4aef6347fbcc7b5c5e3ce3f8381ce805c370021a", size = 5638724, upload-time = "2026-06-25T18:28:43.897Z" },
+    { url = "https://files.pythonhosted.org/packages/23/50/1df335fdf9b527b3933f1e94ab6fc720ad314260fab8591cb0b6668ff192/obstore-0.11.0-cp311-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:39d04b324fcf984e7050734ebda77b81764025b0c011750201a0d8954087f7aa", size = 5413508, upload-time = "2026-06-25T18:28:45.624Z" },
+    { url = "https://files.pythonhosted.org/packages/de/dc/a259aba149b841ca7c91fea177df9972a60a636b54077beed1a35b254994/obstore-0.11.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:37c0d15d775b1370ef5204ee3919a5ddf7e2592d11815213105f8db031f2ab8d", size = 5619995, upload-time = "2026-06-25T18:28:47.599Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/b4/ec25fdb4d6b060bc6eea647fc0e88f75fcc20fe8d16d67fb0dbe999d323b/obstore-0.11.0-cp311-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:7f468caf9b6e0f12ff151e5fe618de5fc9192befa9bd02734b06de4efd2e49f6", size = 5299512, upload-time = "2026-06-25T18:28:49.629Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/e5/29be060d06ec13e2af3d1b6cfb77b7c37f8be6c56b77295c945fefad73e4/obstore-0.11.0-cp311-abi3-musllinux_1_2_i686.whl", hash = "sha256:42d8e8fad85be8ee488c1a9a9b7c6a42128abb84e67175da40d3d1165c1846df", size = 5427026, upload-time = "2026-06-25T18:28:51.317Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b7/577a965f440e9ea64243518663f9d16be7df8eafc7123818e8e841fa21ce/obstore-0.11.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9c8fd2a544e2e0b926669c47fcfb8d2314e234abc240ea165dae04ee42e1d7ac", size = 5869187, upload-time = "2026-06-25T18:28:53.166Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/18/8fdbaee22bfd5b9c44e1fdff8ca0508e2fe60c42bf9fc85f0c9c27b4ecf2/obstore-0.11.0-cp311-abi3-win_amd64.whl", hash = "sha256:6fb3d4678c0f4242d3109362e9b1df5d7b27765f43d5aacb2e81af53a75cb9ef", size = 5329384, upload-time = "2026-06-25T18:28:55.305Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/8b/7555e48ec768728fcfc71a051c6b28d6ddaf1bececf492ce5ef995aab5f0/obstore-0.11.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:f3132393eff9f3f2b543ecbb3bcc12319a7c433fef06493b4350d6854d505a14", size = 5515763, upload-time = "2026-06-25T18:28:57.527Z" },
+    { url = "https://files.pythonhosted.org/packages/23/8f/94d83f3336421cbb5e436ab0ae5695eae72f7c82990d6b1ac090712c8052/obstore-0.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a3a8da19b47af4c14ecc694209b3c18ac6d89f96be5656ee3a19b77947c14155", size = 4649491, upload-time = "2026-06-25T18:28:59.386Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/86/11f4e1f51a8c6cf21a5915c018d2357201ad3c5799d418f0c6529fafaab2/obstore-0.11.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e91298b9b6c3a0408c28eece62bca6c5b6cda2f6350351d84e07b4dc8fb2631f", size = 5060659, upload-time = "2026-06-25T18:29:01.139Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e7/fd3036b0923d10e878e2073020f1ef692a618ed1cc3980d3e4a468c93713/obstore-0.11.0-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3422c532486671dfb5e3e739bf15ec9ca2a8da544a3c23b74ae3857dcab1c6a8", size = 5277058, upload-time = "2026-06-25T18:29:02.96Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/a7/b016c3ac6857ac856326dc0a292e3871b8500d03f25f3b90e168b05de357/obstore-0.11.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3de027ce46cf0592c2b41654e2c27dbc52a4a726f6fbc511380acc0da3a9f658", size = 5475852, upload-time = "2026-06-25T18:29:05.032Z" },
+    { url = "https://files.pythonhosted.org/packages/85/9e/644ffe8db7757de7f71f94a036ab24222bccb4de290d3ca69f76547e812d/obstore-0.11.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1a80a95548678210bc336b866e37139c293565c3b163eb3fef2433d5d6640a33", size = 5363082, upload-time = "2026-06-25T18:29:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/0b/26af6b5fa6ba96af84086f44f78b4e5b0af1729c31402d7b28c68989d174/obstore-0.11.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acaa261dc15efb95bbeca06f8fe9b47ee23d7302a6aa1fa3a9654baab8b23d7c", size = 5629116, upload-time = "2026-06-25T18:29:08.771Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ce/f30d502991c6719b2fbd7b8385ef3e39da07bfca099108bcc5eeed8b9c20/obstore-0.11.0-cp314-cp314t-manylinux_2_24_aarch64.whl", hash = "sha256:a3300cabbc3129670987b3723629c791d83c117ef1b6a0c670c2043648e000a1", size = 5404534, upload-time = "2026-06-25T18:29:11.294Z" },
+    { url = "https://files.pythonhosted.org/packages/52/20/d5bf5f816e868717ba647ed9a2109e800deb402d0265d410456b3fcb4376/obstore-0.11.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f4e6a9480843645cd4ee122c41d5c5a46a56f1e9cdda85638826f2e0e439fe5c", size = 5613159, upload-time = "2026-06-25T18:29:13.414Z" },
+    { url = "https://files.pythonhosted.org/packages/db/b4/6d4c1c211e3b06cc8554189e0d4406e8fa1f98ed55f9213b8e398a11599f/obstore-0.11.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:9fb2b1814c4314b8903f4e2ebbe8c3365fea6543669615ee9a0288b0d3a2edeb", size = 5286279, upload-time = "2026-06-25T18:29:15.424Z" },
+    { url = "https://files.pythonhosted.org/packages/02/5e/d7b5589424a56171b16ab94cf92eb493490c300aaa044913bbdd94cace68/obstore-0.11.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:63fb9b072815eafe4705f617f567d896b1c858adcb390795fa1e269367791031", size = 5401780, upload-time = "2026-06-25T18:29:17.514Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/18/841baea8936e51a18b0e5d4c51f09c0a7798cb73b027e9794be2362a0f0b/obstore-0.11.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:086fafba314ff98cfab1c4bf7814699e862513e8889720cf6f7462296cb32787", size = 5853618, upload-time = "2026-06-25T18:29:19.354Z" },
+    { url = "https://files.pythonhosted.org/packages/83/9a/d6127f5422b78e0222b0a9eadcfd7a5aa8d873a9498da7d4a77d4ac8ce2e/obstore-0.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:676d1154f6f08721110f9b7d14ee3a3c0293abaf9da135bb90f54e276dca1cac", size = 5314113, upload-time = "2026-06-25T18:29:21.209Z" },
+    { url = "https://files.pythonhosted.org/packages/61/17/6ddc3e035a0adc3397bc2b9ea4ebe52db6711ad87ddf0180b7675fa25d6a/obstore-0.11.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c30aec09acff505e27b7392eb5e4b7bb7073d3f21e44ea43a64913369d83cba0", size = 5500652, upload-time = "2026-06-25T18:29:23.423Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/66/0e8ebfebf7151b401dee19373b3a699b179c3687bea5d684adbef2c7c67d/obstore-0.11.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:32ec11db91b85e4482baf2c8c0f43b469e8788765cd844839c84468516446181", size = 4681675, upload-time = "2026-06-25T18:29:25.766Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/84/717505cdf8e453ef16be74e6ca4204629722227c1cbecf3719a17513dd9a/obstore-0.11.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a7f574cf222156f95846fda755365085e8c825be48359f32fa57935fa79f172", size = 5078712, upload-time = "2026-06-25T18:29:27.502Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/e4/a3a87a9ef6973cc59f8cd3543b74cde3bac81ff18bfdab80a460c95d5df0/obstore-0.11.0-pp311-pypy311_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:193d8af924c24ab60c342d64c55896f8cae026851182ade6f1b650789d17b84a", size = 5309116, upload-time = "2026-06-25T18:29:29.912Z" },
+    { url = "https://files.pythonhosted.org/packages/98/40/af6699c140cd4f5fb638ccad2053b096ebaa8b5fcd2a2c5176113c1bc847/obstore-0.11.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed68e3653f12a995bca4372cdccf8663bd3df2ce9750132d11c4c04489e2dc61", size = 5503037, upload-time = "2026-06-25T18:29:32.396Z" },
+    { url = "https://files.pythonhosted.org/packages/22/0c/e83123e8e2d2075dd686ed1c13e462c19b9c57ec0a67c316bdde862c6def/obstore-0.11.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ee8d5aa13158e39d20e76730fdc81a50fd80f6d415a1dc327cf317e5c4e2e878", size = 5368241, upload-time = "2026-06-25T18:29:34.366Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/94/d1cba6347ed6e540765e6db2c2a262f8aba50ae40a0d47749465c42e94a0/obstore-0.11.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca0a6bef07fc26990828528090c6b41860ca949d3cf1b81b24854674173b47ba", size = 5644399, upload-time = "2026-06-25T18:29:36.482Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/24/a9033feffb423d5f6a7bdc85041e9b9e1f67b2835fd484427d005ed17187/obstore-0.11.0-pp311-pypy311_pp73-manylinux_2_24_aarch64.whl", hash = "sha256:c9c6ccc06801afb0fc0e8f0e8c957f643c2c4f7e349eb36a736167e280709c6c", size = 5423124, upload-time = "2026-06-25T18:29:38.513Z" },
+    { url = "https://files.pythonhosted.org/packages/69/e8/2ee75c66bc703670bbf1aa51c320a4d282efa85adf8e9fa3f7467c02513e/obstore-0.11.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:9555f36a0724d34d747b38cda0cb55b3f650a22e8671614037c52190bf4da6cc", size = 5630049, upload-time = "2026-06-25T18:29:40.647Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/72/76b3099664d997747e5e7b11b322926d486d1471266941fc0103d912b666/obstore-0.11.0-pp311-pypy311_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:f0c1527daf1c75d3f70ee3f6bef2767d8b07005cd7a5b43dc8c96a1323f3ac54", size = 5308482, upload-time = "2026-06-25T18:29:42.643Z" },
+    { url = "https://files.pythonhosted.org/packages/34/96/03594ac63d7b1a0e773b0c604c38003ee828e6d5348488eaeb2c57bdc29e/obstore-0.11.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:ed5910bde525d7d936d36dc78c7d4c07b57b6c9b55e402357b107103595d56ff", size = 5433377, upload-time = "2026-06-25T18:29:45.323Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/53/07226c948760264fb7ba253825ecbe5941abfac9875e6d1b2679cc82e3ef/obstore-0.11.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:65c0208ead516c1a79afced16f2cda9b5542886123e53ea0a8a7d5d56b86fba5", size = 5868708, upload-time = "2026-06-25T18:29:47.668Z" },
+]
+
+[[package]]
 name = "orjson"
 version = "3.11.7"
 source = { registry = "https://pypi.org/simple" }
@@ -4491,23 +4541,23 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version < '3.12'" },
-    { name = "babel", marker = "python_full_version < '3.12'" },
-    { name = "colorama", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
-    { name = "docutils", marker = "python_full_version < '3.12'" },
-    { name = "imagesize", marker = "python_full_version < '3.12'" },
-    { name = "jinja2", marker = "python_full_version < '3.12'" },
-    { name = "packaging", marker = "python_full_version < '3.12'" },
-    { name = "pygments", marker = "python_full_version < '3.12'" },
-    { name = "requests", marker = "python_full_version < '3.12'" },
-    { name = "roman-numerals", marker = "python_full_version < '3.12'" },
-    { name = "snowballstemmer", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.12'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils" },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
 wheels = [
@@ -4524,23 +4574,23 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version >= '3.12'" },
-    { name = "babel", marker = "python_full_version >= '3.12'" },
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "docutils", marker = "python_full_version >= '3.12'" },
-    { name = "imagesize", marker = "python_full_version >= '3.12'" },
-    { name = "jinja2", marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "requests", marker = "python_full_version >= '3.12'" },
-    { name = "roman-numerals", marker = "python_full_version >= '3.12'" },
-    { name = "snowballstemmer", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.12'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils" },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
 wheels = [
@@ -4571,7 +4621,7 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1d/f6/bdd93582b2aaad2cfe9eb5695a44883c8bc44572dd3c351a947acbb13789/sphinx_autodoc_typehints-3.6.1.tar.gz", hash = "sha256:fa0b686ae1b85965116c88260e5e4b82faec3687c2e94d6a10f9b36c3743e2fe", size = 37563, upload-time = "2026-01-02T15:23:46.543Z" }
 wheels = [
@@ -4588,7 +4638,7 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/64/5f/ebcaed1a67e623e4a7622808a8be6b0fd8344313e185f62e85a26b0ce26a/sphinx_autodoc_typehints-3.6.3.tar.gz", hash = "sha256:6c387b47d9ad5e75b157810af5bad46901f0a22708ed5e4adf466885a9c60910", size = 38288, upload-time = "2026-02-18T04:22:08.384Z" }
 wheels = [


### PR DESCRIPTION
<!-- markdownlint-disable MD013-->
# PhysicsNeMo Curator Pull Request

## Description

Adds OPERA radar ingestion to the `da` domain, plus two pipeline
capabilities it needs to run.

- **`OPERASource`** — new DataArray source for EUMETNET OPERA pan-European
  radar composites, fetched from the CloudFerro S3 archive via
  `earth2studio.data.OPERA`. Each pipeline index maps to one timestamp and
  yields dims `(time, variable, y, x)` on OPERA's native Lambert Equal-Area
  grid. Supports `refc`, `tprate`, and `tp01`. Defaults to `cache=False` to
  match `HRRRSource` and `GFSSource`.

- **`ZarrSink(track_valid=True)`** — a pre-allocated store is sized up front,
  so an index that was never written is indistinguishable from one holding
  legitimate fill values. This is necessary for OPERA because the upstream archive
  is missing some timestamps. The opt-in flag records a per-index boolean array,
  flipped only once every pre-allocated variable has been written at that
  index so a partial write is not mistaken for a complete one. It is chunked
  `(1,)` so concurrent workers never contend for the same chunk;
  `finalize()` consolidates it into one chunk for fast reads once all workers
  are done, and a resumed run restores the per-index chunking. 

- **NaN-aware statistics fix** — `DataArrayStatsFilter` treated
  every element of a sample as an observation, so one NaN gridpoint
  permanently poisoned the mean, variance, and skewness for that element.
  In the OPERA data, pixels without an active radar echo are filled with NaN
  and need a way to calculate their statistics off of their finite elements alone.
  Non-finite values are now skipped per element, with the per-element count of
  finite observations persisted as `welford_n` so Chan's parallel merge stays
  exact when a gridpoint is observed by some workers but not others. Stores
  written before this change still merge via the existing fallback path.

### Note on the earth2studio bump

`uv.lock` pinned `earth2studio` at `c3d1625` (2026-05-20), which predates the
upstream OPERA data source (NVIDIA/earth2studio#920, merged 2026-06-11).
`OPERASource` is not importable against that pin, so the lock is bumped to
`166b2d2` (`0.15.0a0` → `0.18.0a0`). The existing ERA5, HRRR, and GFS
end-to-end tests pass against the newer revision.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/physicsnemo-curator/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] An [issue](https://github.com/NVIDIA/physicsnemo-curator/issues) is linked to this pull request.

## Dependencies

None added. `earth2studio` is bumped to an existing revision of `main` (see
above); no new packages are introduced.
